### PR TITLE
Use ascii encoding to unpack message into buffer

### DIFF
--- a/index.js
+++ b/index.js
@@ -190,7 +190,7 @@ class LedgerBridgeKeyring extends EventEmitter {
   // For personal_sign, we need to prefix the message:
   signPersonalMessage (withAccount, message) {
     const humanReadableMsg = this._toAscii(message)
-    const bufferMsg = Buffer.from(humanReadableMsg).toString('hex')
+    const bufferMsg = Buffer.from(humanReadableMsg, "ascii").toString('hex')
     return new Promise((resolve, reject) => {
       this.unlock()
         .then(_ => {


### PR DESCRIPTION
signPersonalMessage decodes the message as ascii, but Buffer.from() defaults to using a utf-8 decoder for binary strings such as hashes and unicode data, this can lead to inaccurate decoding. Using the ascii decoder ensures that the binary buffer corresponds to the original message.

No test is added with this commit, as the existing tests of this function only ensure that a event listener is created. I have tested this with my ledger on a wide range of inputs (both plaintext and binary) and it seems produce proper signatures.