### PR TITLE
Upgrade ledgerjs and fix signing issues

### DIFF
--- a/index.js
+++ b/index.js
@@ -160,6 +160,7 @@ class LedgerBridgeKeyring extends EventEmitter {
             params: {
               tx: tx.serialize().toString('hex'),
               hdPath,
+              to: ethUtil.bufferToHex(tx.to).toLowerCase()
             },
           },
           ({success, payload}) => {

--- a/index.js
+++ b/index.js
@@ -185,13 +185,13 @@ class LedgerBridgeKeyring extends EventEmitter {
   }
 
   signMessage (withAccount, data) {
-    throw new Error('Not supported on this device')
+    return Promise.reject(new Error('Not supported on this device'))
   }
 
   // For personal_sign, we need to prefix the message:
   signPersonalMessage (withAccount, message) {
     const humanReadableMsg = this._toAscii(message)
-    const bufferMsg = Buffer.from(humanReadableMsg).toString('hex')
+    const bufferMsg = Buffer.from(humanReadableMsg, "ascii").toString('hex')
     return new Promise((resolve, reject) => {
       this.unlock()
         .then(_ => {
@@ -231,11 +231,11 @@ class LedgerBridgeKeyring extends EventEmitter {
   }
 
   signTypedData (withAccount, typedData) {
-    throw new Error('Not supported on this device')
+    return Promise.reject(new Error('Not supported on this device'))
   }
 
   exportAccount (address) {
-    throw new Error('Not supported on this device')
+    return Promise.reject(new Error('Not supported on this device'))
   }
 
   forgetDevice () {

--- a/index.js
+++ b/index.js
@@ -185,13 +185,11 @@ class LedgerBridgeKeyring extends EventEmitter {
   }
 
   signMessage (withAccount, data) {
-    return Promise.reject(new Error('Not supported on this device'))
+    return this.signPersonalMessage(withAccount, data);
   }
 
   // For personal_sign, we need to prefix the message:
   signPersonalMessage (withAccount, message) {
-    const humanReadableMsg = this._toAscii(message)
-    const bufferMsg = Buffer.from(humanReadableMsg, "ascii").toString('hex')
     return new Promise((resolve, reject) => {
       this.unlock()
         .then(_ => {
@@ -206,7 +204,7 @@ class LedgerBridgeKeyring extends EventEmitter {
             action: 'ledger-sign-personal-message',
             params: {
               hdPath,
-              message: bufferMsg,
+              message: ethUtil.stripHexPrefix(message),
             },
           },
           ({success, payload}) => {
@@ -231,11 +229,11 @@ class LedgerBridgeKeyring extends EventEmitter {
   }
 
   signTypedData (withAccount, typedData) {
-    return Promise.reject(new Error('Not supported on this device'))
+    throw new Error('Not supported on this device')
   }
 
   exportAccount (address) {
-    return Promise.reject(new Error('Not supported on this device'))
+    throw new Error('Not supported on this device')
   }
 
   forgetDevice () {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eth-ledger-bridge-keyring",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "A MetaMask compatible keyring, for ledger hardware wallets",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eth-ledger-bridge-keyring",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "description": "A MetaMask compatible keyring, for ledger hardware wallets",
   "main": "index.js",
   "scripts": {

--- a/test/test-eth-ledger-bridge-keyring.js
+++ b/test/test-eth-ledger-bridge-keyring.js
@@ -291,10 +291,15 @@ describe('LedgerBridgeKeyring', function () {
     })
 
     describe('signMessage', function () {
-        it('should throw an error because it is not supported', function () {
-            expect(_ => {
-                keyring.signMessage()
-            }).to.throw('Not supported on this device')
+        it('should call create a listener waiting for the iframe response', function (done) {
+
+            chai.spy.on(window, 'addEventListener')
+            setTimeout(_ => {
+                keyring.signPersonalMessage(fakeAccounts[0], '0x123')
+                expect(window.addEventListener).to.have.been.calledWith('message')
+            }, 1800)
+            chai.spy.restore(window, 'addEventListener')
+            done()
         })
     })
 


### PR DESCRIPTION
Similar to https://github.com/MetaMask/eth-trezor-keyring/pull/16

This PR fixes a few things:

- Inability of sign UTF8 chars using `personalSign`

![utf8](https://user-images.githubusercontent.com/1247834/55371251-89e39b00-54cb-11e9-8fce-bf1b4f039d23.gif)

Fixes the ledger part of MetaMask/metamask-extension#5523

- Enable `eth_sign`, which allows to sign a hex message

DEMO of `eth_sign` working at: https://danfinlay.github.io/js-eth-personal-sign-examples/

![eth-sign](https://user-images.githubusercontent.com/1247834/55371181-425d0f00-54cb-11e9-9539-06f3f4f0d703.gif)

- Adds the extra "TO" parameter required for signing transactions #11 
