### PR TITLE
Update package scope + contents

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,12 +1,19 @@
 {
-  "name": "eth-ledger-bridge-keyring",
+  "name": "@metamask/eth-ledger-bridge-keyring",
   "version": "0.2.1",
   "description": "A MetaMask compatible keyring, for ledger hardware wallets",
   "main": "index.js",
+  "files": [
+    "index.js"
+  ],
   "scripts": {
     "test": "mocha",
     "lint": "./node_modules/.bin/eslint . --ext .js",
     "lint:fix": "./node_modules/.bin/eslint --fix . --ext .js"
+  },
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org/",
+    "access": "public"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
This PR updates the package name (now `@metamask/eth-ledger-bridge-keyring`) and updates the files list to include just the `index.js` file.