### PR TITLE
Remove BIP44 accounts without indexes during deserialization

### DIFF
--- a/index.js
+++ b/index.js
@@ -49,6 +49,13 @@ class LedgerBridgeKeyring extends EventEmitter {
     this.accounts = opts.accounts || []
     this.accountIndexes = opts.accountIndexes || {}
     this.implementFullBIP44 = opts.implementFullBIP44 || false
+
+    if (this._isBIP44()) {
+      // Remove accounts that don't have corresponding account indexes
+      this.accounts = this.accounts
+        .filter(account => Boolean(this.accountIndexes[ethUtil.toChecksumAddress(account)]))
+    }
+
     return Promise.resolve()
   }
 


### PR DESCRIPTION
The index of each BIP44 account is saved when that account is connected to ensure we can determine the account's HD path later on for signing. This should work for any new accounts that are added, but pre-existing ledger accounts won't have this index, so signing will fail.

Accounts with missing indexes are now removed when deserializing, so that it's more obvious to the user that they need to re-add them.