### PR TITLE
Fix account index check for index zero

### DIFF
--- a/index.js
+++ b/index.js
@@ -53,7 +53,7 @@ class LedgerBridgeKeyring extends EventEmitter {
     if (this._isBIP44()) {
       // Remove accounts that don't have corresponding account indexes
       this.accounts = this.accounts
-        .filter(account => Boolean(this.accountIndexes[ethUtil.toChecksumAddress(account)]))
+        .filter(account => Object.keys(this.accountIndexes).includes(ethUtil.toChecksumAddress(account)))
     }
 
     return Promise.resolve()
@@ -163,7 +163,7 @@ class LedgerBridgeKeyring extends EventEmitter {
           let hdPath
           if (this._isBIP44()) {
             const checksummedAddress = ethUtil.toChecksumAddress(address)
-            if (!this.accountIndexes[checksummedAddress]) {
+            if (!Object.keys(this.accountIndexes).includes(checksummedAddress)) {
               reject(new Error(`Ledger: Index for address '${checksummedAddress}' not found`))
             }
             hdPath = this._getPathForIndex(this.accountIndexes[checksummedAddress])
@@ -212,7 +212,7 @@ class LedgerBridgeKeyring extends EventEmitter {
           let hdPath
           if (this._isBIP44()) {
             const checksummedAddress = ethUtil.toChecksumAddress(withAccount)
-            if (!this.accountIndexes[checksummedAddress]) {
+            if (!Object.keys(this.accountIndexes).includes(checksummedAddress)) {
               reject(new Error(`Ledger: Index for address '${checksummedAddress}' not found`))
             }
             hdPath = this._getPathForIndex(this.accountIndexes[checksummedAddress])


### PR DESCRIPTION
The check for whether an account index is set is a _falsey_ check on the account index, which means that index zero is interpreted as false.

Instead we now check that the address is present as a key.