### PR TITLE
Remove ecmaFeatures from ESLint config

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -11,11 +11,6 @@ module.exports = {
 
   parserOptions: {
     ecmaVersion: 2017,
-    ecmaFeatures: {
-      arrowFunctions: true,
-      classes: true,
-      experimentalObjectRestSpread: true,
-    },
   },
 
   plugins: [


### PR DESCRIPTION
This change removes the `ecmaFeatures` properties from the ESLint config as arrow functions and classes are part of the specified `ecmaVersion` and experimental options shouldn't be added.