### PR TITLE
Support multiple accounts

### DIFF
--- a/index.js
+++ b/index.js
@@ -73,16 +73,18 @@ class LedgerBridgeKeyring extends EventEmitter {
 
     // try to migrate non-bip44 accounts too
     if (!this._isBIP44()) {
-      this.accounts.filter((account) => !Object.keys(this.accountDetails).includes(ethUtil.toChecksumAddress(account))).forEach((account) => {
-        try {
-          this.accountDetails[ethUtil.toChecksumAddress(account)] = {
-            bip44: false,
-            hdPath: this._pathFromAddress(account),
+      this.accounts
+        .filter((account) => !Object.keys(this.accountDetails).includes(ethUtil.toChecksumAddress(account)))
+        .forEach((account) => {
+          try {
+            this.accountDetails[ethUtil.toChecksumAddress(account)] = {
+              bip44: false,
+              hdPath: this._pathFromAddress(account),
+            }
+          } catch (e) {
+            console.log(`failed to migrate account ${account}`)
           }
-        } catch (e) {
-          console.log(`failed to migrate account ${account}`)
-        }
-      })
+        })
     }
   }
 

--- a/index.js
+++ b/index.js
@@ -106,7 +106,6 @@ class LedgerBridgeKeyring extends EventEmitter {
         .then(async (_) => {
           const from = this.unlockedAccount
           const to = from + n
-          this.accounts = []
           for (let i = from; i < to; i++) {
             let address
             if (this._isBIP44()) {
@@ -116,7 +115,10 @@ class LedgerBridgeKeyring extends EventEmitter {
             } else {
               address = this._addressFromIndex(pathBase, i)
             }
-            this.accounts.push(address)
+
+            if (!this.accounts.includes(address)) {
+              this.accounts.push(address)
+            }
             this.page = 0
           }
           resolve(this.accounts)

--- a/test/test-eth-ledger-bridge-keyring.js
+++ b/test/test-eth-ledger-bridge-keyring.js
@@ -181,6 +181,23 @@ describe('LedgerBridgeKeyring', function () {
           })
       })
     })
+
+    describe('when called multiple times', function () {
+      it('should not remove existing accounts', function (done) {
+        keyring.setAccountToUnlock(0)
+        keyring.addAccounts(1)
+          .then(function () {
+            keyring.setAccountToUnlock(1)
+            keyring.addAccounts(1)
+              .then((accounts) => {
+                assert.equal(accounts.length, 2)
+                assert.equal(accounts[0], fakeAccounts[0])
+                assert.equal(accounts[1], fakeAccounts[1])
+                done()
+              })
+          })
+      })
+    })
   })
 
   describe('removeAccount', function () {

--- a/test/test-eth-ledger-bridge-keyring.js
+++ b/test/test-eth-ledger-bridge-keyring.js
@@ -6,6 +6,7 @@ const chai = require('chai')
 const spies = require('chai-spies')
 const EthereumTx = require('ethereumjs-tx')
 const HDKey = require('hdkey')
+const ethUtil = require('ethereumjs-util')
 const LedgerBridgeKeyring = require('..')
 
 const { expect } = chai
@@ -91,22 +92,72 @@ describe('LedgerBridgeKeyring', function () {
   })
 
   describe('deserialize', function () {
-    it('serializes what it deserializes', function (done) {
+    it('serializes what it deserializes', function () {
 
+      const account = fakeAccounts[0]
+      const checksum = ethUtil.toChecksumAddress(account)
       const someHdPath = `m/44'/60'/0'/1`
-
-      keyring.deserialize({
+      const accountDetails = {}
+      accountDetails[checksum] = {
+        index: 0,
+        hdPath: someHdPath,
+      }
+      return keyring.deserialize({
         page: 10,
         hdPath: someHdPath,
-        accounts: [],
+        accounts: [account],
+        accountDetails,
       })
         .then(() => {
           return keyring.serialize()
         }).then((serialized) => {
-          assert.equal(serialized.accounts.length, 0, 'restores 0 accounts')
+          assert.equal(serialized.accounts.length, 1, 'restores 1 account')
           assert.equal(serialized.bridgeUrl, 'https://metamask.github.io/eth-ledger-bridge-keyring', 'restores bridgeUrl')
           assert.equal(serialized.hdPath, someHdPath, 'restores hdPath')
-          done()
+          assert.deepEqual(serialized.accountDetails, accountDetails, 'restores accountDetails')
+        })
+    })
+
+    it('should migrate accountIndexes to accountDetails', function () {
+
+      const someHdPath = `m/44'/60'/0'/0/0`
+      const account = fakeAccounts[1]
+      const checksum = ethUtil.toChecksumAddress(account)
+      const accountIndexes = {}
+      accountIndexes[checksum] = 1
+      return keyring.deserialize({
+        accounts: [account],
+        accountIndexes,
+        hdPath: someHdPath,
+      })
+        .then(() => {
+          assert.equal(keyring.hdPath, someHdPath)
+          assert.equal(keyring.accounts[0], account)
+          assert.deepEqual(keyring.accountDetails[checksum], {
+            bip44: true,
+            hdPath: `m/44'/60'/1'/0/0`,
+          })
+
+        })
+    })
+
+    it('should migrate non-bip44 accounts to accountDetails', function () {
+
+      const someHdPath = `m/44'/60'/0'`
+      const account = fakeAccounts[1]
+      const checksum = ethUtil.toChecksumAddress(account)
+      return keyring.deserialize({
+        accounts: [account],
+        hdPath: someHdPath,
+      })
+        .then(() => {
+          assert.equal(keyring.hdPath, someHdPath)
+          assert.equal(keyring.accounts[0], account)
+          assert.deepEqual(keyring.accountDetails[checksum], {
+            bip44: false,
+            hdPath: `m/44'/60'/0'/1`,
+          })
+
         })
     })
   })
@@ -180,6 +231,34 @@ describe('LedgerBridgeKeyring', function () {
             done()
           })
       })
+    })
+
+    it('stores account details for bip44 accounts', function () {
+      keyring.setHdPath(`m/44'/60'/0'/0/0`)
+      keyring.setAccountToUnlock(1)
+      chai.spy.on(keyring, 'unlock', (_) => Promise.resolve(fakeAccounts[1]))
+      after(function () {
+        chai.spy.restore(keyring, 'unlock')
+      })
+      return keyring.addAccounts(1)
+        .then((accounts) => {
+          assert.deepEqual(keyring.accountDetails[accounts[0]], {
+            bip44: true,
+            hdPath: `m/44'/60'/1'/0/0`,
+          })
+        })
+    })
+
+    it('stores account details for non-bip44 accounts', function () {
+      keyring.setHdPath(`m/44'/60'/0'`)
+      keyring.setAccountToUnlock(2)
+      return keyring.addAccounts(1)
+        .then((accounts) => {
+          assert.deepEqual(keyring.accountDetails[accounts[0]], {
+            bip44: false,
+            hdPath: `m/44'/60'/0'/2`,
+          })
+        })
     })
 
     describe('when called multiple times', function () {
@@ -394,7 +473,7 @@ describe('LedgerBridgeKeyring', function () {
 
       return keyring.unlockAccountByAddress(fakeAccounts[0])
         .then((hdPath) => {
-          assert.equal(hdPath, '44\'/60\'/0\'/0')
+          assert.equal(hdPath, 'm/44\'/60\'/0\'/0')
         })
     })
 

--- a/test/test-eth-ledger-bridge-keyring.js
+++ b/test/test-eth-ledger-bridge-keyring.js
@@ -378,4 +378,34 @@ describe('LedgerBridgeKeyring', function () {
     })
   })
 
+  describe('unlockAccountByAddress', function () {
+
+    beforeEach(async function () {
+      keyring.setAccountToUnlock(0)
+      await keyring.addAccounts()
+    })
+
+    afterEach(function () {
+      chai.spy.restore(keyring, 'unlock')
+    })
+
+    it('should unlock the given account if found on device', function () {
+      chai.spy.on(keyring, 'unlock', (_) => Promise.resolve(fakeAccounts[0]))
+
+      return keyring.unlockAccountByAddress(fakeAccounts[0])
+        .then((hdPath) => {
+          assert.equal(hdPath, '44\'/60\'/0\'/0')
+        })
+    })
+
+    it('should reject if the account is not found on device', function () {
+
+      const requestedAccount = fakeAccounts[0]
+      const incorrectAccount = fakeAccounts[1]
+
+      chai.spy.on(keyring, 'unlock', (_) => Promise.resolve(incorrectAccount))
+
+      return assert.rejects(() => keyring.unlockAccountByAddress(requestedAccount), new Error(`Ledger: Account ${fakeAccounts[0]} does not belong to the connected device`))
+    })
+  })
 })


### PR DESCRIPTION
This allows to use multiple accounts from one or more ledger devices simultaneously without setting them up repeatedly (MetaMask/metamask-extension#6649). 