### PR TITLE
Add bip44ChildIndices for HD path derivation

### DIFF
--- a/test/test-eth-ledger-bridge-keyring.js
+++ b/test/test-eth-ledger-bridge-keyring.js
@@ -236,16 +236,25 @@ describe('LedgerBridgeKeyring', function () {
     it('stores account details for bip44 accounts', function () {
       keyring.setHdPath(`m/44'/60'/0'/0/0`)
       keyring.setAccountToUnlock(1)
-      chai.spy.on(keyring, 'unlock', (_) => Promise.resolve(fakeAccounts[1]))
+      chai.spy.on(keyring, 'unlock', function (args) {
+        const matches = args && args.match(/.*\/(\d)/u)
+        return Promise.resolve(fakeAccounts[(matches && matches[1]) || 1])
+      })
       after(function () {
         chai.spy.restore(keyring, 'unlock')
       })
       return keyring.addAccounts(1)
         .then((accounts) => {
+
           assert.deepEqual(keyring.accountDetails[accounts[0]], {
             bip44: true,
             hdPath: `m/44'/60'/1'/0/0`,
           })
+          assert.deepEqual(keyring.accountDetails[accounts[1]], {
+            bip44: true,
+            hdPath: `m/44'/60'/1'/0/1`,
+          })
+
         })
     })
 


### PR DESCRIPTION
I have recently purchased a ledger device and found that I was unable to import all my accounts that were previously generated by metamask itself with one seed phrase.

After looking at the code, it seemed that the childIndex in the HDpath is unused (or always set to 0). Metamask seems to have used this index to generate a new address within the same account. This second account is not detected without this patch.

I'm not sure whether this is a known issue but after rebuilding metamask with this change I'm now able to see all my addresses for this account.

Any idea if it can be integrated as it stands here? Or is there any explanation as to why the childIndices are always fixed to 0 here?