### PR TITLE
slightly improve tests

### DIFF
--- a/test/test-eth-ledger-bridge-keyring.js
+++ b/test/test-eth-ledger-bridge-keyring.js
@@ -7,6 +7,8 @@ const spies = require('chai-spies')
 const EthereumTx = require('ethereumjs-tx')
 const HDKey = require('hdkey')
 const ethUtil = require('ethereumjs-util')
+const sigUtil = require('eth-sig-util')
+
 const LedgerBridgeKeyring = require('..')
 
 const { expect } = chai
@@ -47,10 +49,19 @@ chai.use(spies)
 describe('LedgerBridgeKeyring', function () {
 
   let keyring
+  let sandbox
 
-  beforeEach(function () {
+  beforeEach(async function () {
+    sandbox = chai.spy.sandbox()
     keyring = new LedgerBridgeKeyring()
     keyring.hdk = fakeHdKey
+    keyring.setAccountToUnlock(fakeAccounts[0])
+    sandbox.on(keyring, 'unlock', (_) => Promise.resolve(fakeAccounts[0]))
+    await keyring.addAccounts()
+  })
+
+  afterEach(function () {
+    sandbox.restore()
   })
 
   describe('Keyring.type', function () {
@@ -85,7 +96,7 @@ describe('LedgerBridgeKeyring', function () {
           assert.equal(output.bridgeUrl, 'https://metamask.github.io/eth-ledger-bridge-keyring')
           assert.equal(output.hdPath, `m/44'/60'/0'`)
           assert.equal(Array.isArray(output.accounts), true)
-          assert.equal(output.accounts.length, 0)
+          assert.equal(output.accounts.length, 1)
           done()
         })
     })
@@ -236,13 +247,11 @@ describe('LedgerBridgeKeyring', function () {
     it('stores account details for bip44 accounts', function () {
       keyring.setHdPath(`m/44'/60'/0'/0/0`)
       keyring.setAccountToUnlock(1)
-      chai.spy.on(keyring, 'unlock', (_) => Promise.resolve(fakeAccounts[1]))
-      after(function () {
-        chai.spy.restore(keyring, 'unlock')
-      })
+      sandbox.restore(keyring, 'unlock')
+      sandbox.on(keyring, 'unlock', (_) => Promise.resolve(fakeAccounts[1]))
       return keyring.addAccounts(1)
         .then((accounts) => {
-          assert.deepEqual(keyring.accountDetails[accounts[0]], {
+          assert.deepEqual(keyring.accountDetails[accounts[1]], {
             bip44: true,
             hdPath: `m/44'/60'/1'/0/0`,
           })
@@ -254,7 +263,7 @@ describe('LedgerBridgeKeyring', function () {
       keyring.setAccountToUnlock(2)
       return keyring.addAccounts(1)
         .then((accounts) => {
-          assert.deepEqual(keyring.accountDetails[accounts[0]], {
+          assert.deepEqual(keyring.accountDetails[accounts[1]], {
             bip44: false,
             hdPath: `m/44'/60'/0'/2`,
           })
@@ -369,6 +378,8 @@ describe('LedgerBridgeKeyring', function () {
     const accountIndex = 5
     let accounts = []
     beforeEach(async function () {
+      keyring = new LedgerBridgeKeyring()
+      keyring.hdk = fakeHdKey
       keyring.setAccountToUnlock(accountIndex)
       await keyring.addAccounts()
       accounts = await keyring.getAccounts()
@@ -382,19 +393,6 @@ describe('LedgerBridgeKeyring', function () {
     it('returns the expected', function () {
       const expectedAccount = fakeAccounts[accountIndex]
       assert.equal(accounts[0], expectedAccount)
-    })
-  })
-
-  describe('signMessage', function () {
-    it('should call create a listener waiting for the iframe response', function (done) {
-
-      chai.spy.on(window, 'addEventListener')
-      setTimeout((_) => {
-        keyring.signPersonalMessage(fakeAccounts[0], '0x123')
-        expect(window.addEventListener).to.have.been.calledWith('message')
-      }, 1800)
-      chai.spy.restore(window, 'addEventListener')
-      done()
     })
   })
 
@@ -431,46 +429,47 @@ describe('LedgerBridgeKeyring', function () {
   })
 
   describe('signTransaction', function () {
-    it('should call should call create a listener waiting for the iframe response', function (done) {
+    it('should pass serialized transaction to ledger and return signed tx', async function () {
+      sandbox.on(keyring, '_sendMessage', (msg, cb) => {
+        fakeTx.v = ethUtil.bufferToHex(fakeTx.getChainId())
+        fakeTx.r = '0x00'
+        fakeTx.s = '0x00'
+        assert.deepStrictEqual(msg.params, {
+          hdPath: "m/44'/60'/0'/0",
+          to: ethUtil.bufferToHex(fakeTx.to),
+          tx: fakeTx.serialize().toString('hex'),
+        })
+        cb({ success: true, payload: { v: '0x1', r: '0x0', s: '0x0' } })
+      })
 
-      chai.spy.on(window, 'addEventListener')
-      setTimeout((_) => {
-        keyring.signTransaction(fakeAccounts[0], fakeTx)
-        expect(window.addEventListener).to.have.been.calledWith('message')
-      }, 1800)
-      chai.spy.restore(window, 'addEventListener')
-      done()
+      sandbox.on(fakeTx, 'verifySignature', () => true)
 
+      const returnedTx = await keyring.signTransaction(fakeAccounts[0], fakeTx)
+      expect(keyring._sendMessage).to.have.been.called()
+      expect(returnedTx).to.have.property('v')
+      expect(returnedTx).to.have.property('r')
+      expect(returnedTx).to.have.property('s')
     })
   })
 
   describe('signPersonalMessage', function () {
-    it('should call create a listener waiting for the iframe response', function (done) {
+    it('should call create a listener waiting for the iframe response', async function () {
+      sandbox.on(keyring, '_sendMessage', (msg, cb) => {
+        assert.deepStrictEqual(msg.params, {
+          hdPath: "m/44'/60'/0'/0",
+          message: 'some msg',
+        })
+        cb({ success: true, payload: { v: '0x1', r: '0x0', s: '0x0' } })
+      })
 
-      chai.spy.on(window, 'addEventListener')
-      setTimeout((_) => {
-        keyring.signPersonalMessage(fakeAccounts[0], 'some msg')
-        expect(window.addEventListener).to.have.been.calledWith('message')
-      }, 1800)
-      chai.spy.restore(window, 'addEventListener')
-      done()
+      sandbox.on(sigUtil, 'recoverPersonalSignature', () => fakeAccounts[0])
+      await keyring.signPersonalMessage(fakeAccounts[0], 'some msg')
+      expect(keyring._sendMessage).to.have.been.called()
     })
   })
 
   describe('unlockAccountByAddress', function () {
-
-    beforeEach(async function () {
-      keyring.setAccountToUnlock(0)
-      await keyring.addAccounts()
-    })
-
-    afterEach(function () {
-      chai.spy.restore(keyring, 'unlock')
-    })
-
     it('should unlock the given account if found on device', function () {
-      chai.spy.on(keyring, 'unlock', (_) => Promise.resolve(fakeAccounts[0]))
-
       return keyring.unlockAccountByAddress(fakeAccounts[0])
         .then((hdPath) => {
           assert.equal(hdPath, 'm/44\'/60\'/0\'/0')
@@ -481,8 +480,8 @@ describe('LedgerBridgeKeyring', function () {
 
       const requestedAccount = fakeAccounts[0]
       const incorrectAccount = fakeAccounts[1]
-
-      chai.spy.on(keyring, 'unlock', (_) => Promise.resolve(incorrectAccount))
+      sandbox.restore(keyring, 'unlock')
+      sandbox.on(keyring, 'unlock', (_) => Promise.resolve(incorrectAccount))
 
       return assert.rejects(() => keyring.unlockAccountByAddress(requestedAccount), new Error(`Ledger: Account ${fakeAccounts[0]} does not belong to the connected device`))
     })


### PR DESCRIPTION
I am working on upgrading our keyring libraries to support latest versions of `ethereumjs/tx`, but in so doing i'd like to test it so that I can feel confident in my work. When doing that I noticed a few things:

1. Current tests did not cover the response handlers for signTransaction or signPersonalMessage. All that was being tested is that a listener was attached to the window for the postMessage to the iframe.
2. Tests for the above methods are not idempotent because they used a timeout and immediately returned done() without waiting for the result.

This PR:
1. improves the test setup by using a chai sandbox.
2. improves test setup by adding an account in the root level beforeEach
3. improves test setup by spying on/stubbing out the unlock method in the root level beforeEach
4. improves test setup by restoring sandbox afterEach
5. removes a redundant test
6. makes the signPersonalMessage/signTransaction tests idomptent 
7. slightly improves the reliability of the tests by mocking the ledger integration and returning faked data. 
