### PR TITLE
upgrade ethereumjs/tx support

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,12 +39,14 @@
   },
   "dependencies": {
     "eth-sig-util": "^2.0.0",
+    "@ethereumjs/tx": "^3.1.1",
     "ethereumjs-tx": "^1.3.4",
     "ethereumjs-util": "^7.0.9",
     "events": "^2.0.0",
     "hdkey": "0.8.0"
   },
   "devDependencies": {
+    "@ethereumjs/common": "^2.2.0",
     "@metamask/eslint-config": "^3.0.0",
     "babel-eslint": "^10.1.0",
     "chai": "^4.1.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -109,6 +109,22 @@
     lodash "^4.17.19"
     to-fast-properties "^2.0.0"
 
+"@ethereumjs/common@^2.2.0":
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/@ethereumjs/common/-/common-2.2.0.tgz#850a3e3e594ee707ad8d44a11e8152fb62450535"
+  integrity sha512-PyQiTG00MJtBRkJmv46ChZL8u2XWxNBeAthznAUIUiefxPAXjbkuiCZOuncgJS34/XkMbNc9zMt/PlgKRBElig==
+  dependencies:
+    crc-32 "^1.2.0"
+    ethereumjs-util "^7.0.9"
+
+"@ethereumjs/tx@^3.1.1":
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/@ethereumjs/tx/-/tx-3.1.1.tgz#e8d6943baa955b2d197d2f6f7864939991b8feb3"
+  integrity sha512-IuN9EUT6sCZrldVbgQA+XuuxouUvMdoW34qZvlzFtCgjlvKJ848iK/lDTJVVPNb3WndlEu3d2a7Mu474ggdT/g==
+  dependencies:
+    "@ethereumjs/common" "^2.2.0"
+    ethereumjs-util "^7.0.9"
+
 "@metamask/eslint-config@^3.0.0":
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/@metamask/eslint-config/-/eslint-config-3.2.0.tgz#66b9b2bea1616821506501e76de4ac991f34914f"
@@ -477,6 +493,14 @@ contains-path@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/contains-path/-/contains-path-0.1.0.tgz#fe8cf184ff6670b6baef01a9d4861a5cbec4120a"
   integrity sha1-/ozxhP9mcLa67wGp1IYaXL7EEgo=
+
+crc-32@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/crc-32/-/crc-32-1.2.0.tgz#cb2db6e29b88508e32d9dd0ec1693e7b41a18208"
+  integrity sha512-1uBwHxF+Y/4yF5G48fwnKq6QsIXheor3ZLPT80yGBV1oEUwpPojlEhQbWKVw1VwcTQyMGHK1/XMmTjmlsmTTGA==
+  dependencies:
+    exit-on-epipe "~1.0.1"
+    printj "~1.1.0"
 
 create-hash@^1.1.0, create-hash@^1.1.1, create-hash@^1.1.2, create-hash@^1.2.0:
   version "1.2.0"
@@ -910,6 +934,11 @@ evp_bytestokey@^1.0.3:
   dependencies:
     md5.js "^1.3.4"
     safe-buffer "^5.1.1"
+
+exit-on-epipe@~1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/exit-on-epipe/-/exit-on-epipe-1.0.1.tgz#0bdd92e87d5285d267daa8171d0eb06159689692"
+  integrity sha512-h2z5mrROTxce56S+pnvAV890uu7ls7f1kEvVGJbw1OlFH3/mlJ5bkXu0KRyW94v37zzHPiUd55iLn3DA7TjWpw==
 
 external-editor@^3.0.3:
   version "3.1.0"
@@ -1604,6 +1633,11 @@ prelude-ls@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.1.2.tgz#21932a549f5e52ffd9a827f570e04be62a97da54"
   integrity sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=
+
+printj@~1.1.0:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/printj/-/printj-1.1.2.tgz#d90deb2975a8b9f600fb3a1c94e3f4c53c78a222"
+  integrity sha512-zA2SmoLaxZyArQTOPj5LXecR+RagfPSU5Kw1qP+jkWeNlrq+eJZyY2oS68SU1Z/7/myXM4lo9716laOFAVStCQ==
 
 progress@^2.0.0:
   version "2.0.3"


### PR DESCRIPTION
This pull request enables consumers to use newer versions of `@ethereumjs/tx` (previously `ethereumjs-tx`). This enables support for [typed transaction envelopes](https://eips.ethereum.org/EIPS/eip-2718), and features built upon it such as [optional access lists](https://eips.ethereum.org/EIPS/eip-2930).

Support for the oldest supported version of `ethereumjs-tx` prior to this change is maintained. I have not confirmed if this will work for all versions of `ethereumjs-tx` / `@ethereumjs/tx` between those two points. 

Challenges:
1. `@ethereumjs/tx` defaults to immutable objects, which is great... however the previous version of the `signTransaction` method relied upon mutability. The immutability is opt-out but in an effort to allow for taking advantage of immutability at least in the user's domain (not in this repo), this converts immutable Transactions into mutable versions temporarily, then returns an object that is immutable, if the provided transaction object was immutable.
2. `@ethereumjs/tx` has a new 'Common' utility that sets things like chain and hardfork support. This is passed in the options object for `TransactionFactory.fromTxData`. In order to not lock ourselves into having to pass this object around between the consumer and this package, the common options are lifted from the provided transaction object and reapplied to the copies created.
3. `ethereumjs-tx` and `@ethereumjs/tx` have differing accessor methods and construction methods. to work through this I have split the implementation of these two paths up, keeping the most shared code as possible while also creating branches wherein we can rest assured we are dealing with the appropriate type of object.
4. Validation of provided parameters is much more strict in `@ethereumjs/tx` as a result the test case uses a mutable object and stubs out many methods that would otherwise cause tests to fail. I will be following this up with a PR that changes the test structure to use a private key for the HDkey initialization and allows more appropriate levels of testing.
