### PR TITLE
Update to 0.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/eth-ledger-bridge-keyring",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "A MetaMask compatible keyring, for ledger hardware wallets",
   "main": "index.js",
   "files": [


### PR DESCRIPTION
* Includes the required wiring to allow switching between Ledger Live and U2F connections to the Ledger.
* Upgrade of the ethereumjs-util library to 7.0.9
* Renamed `_isBIP44` to more intelligible `_isLedgerLiveHdPath`
* Repo standardization which require minimum version of Node 12 and switch to `yarn`