### PR TITLE
Prevent double delay when waiting for user to make Ledger Live connection

### DIFF
--- a/bundle.js
+++ b/bundle.js
@@ -84,20 +84,12 @@ var LedgerBridge = function () {
             window.parent.postMessage(msg, '*');
         }
     }, {
-        key: 'delay',
-        value: function delay(ms) {
-            return new Promise(function (success) {
-                return setTimeout(success, ms);
-            });
-        }
-    }, {
         key: 'checkTransportLoop',
         value: function checkTransportLoop(i) {
             var _this2 = this;
 
             var iterator = i || 0;
-            return _WebSocketTransport2.default.check(BRIDGE_URL).catch(async function () {
-                await _this2.delay(TRANSPORT_CHECK_DELAY);
+            return _WebSocketTransport2.default.check(BRIDGE_URL, TRANSPORT_CHECK_DELAY).catch(async function () {
                 if (iterator < TRANSPORT_CHECK_LIMIT) {
                     return _this2.checkTransportLoop(iterator + 1);
                 } else {
@@ -112,7 +104,7 @@ var LedgerBridge = function () {
 
             try {
                 if (this.useLedgerLive) {
-                    await _WebSocketTransport2.default.check(BRIDGE_URL).catch(async function () {
+                    await _WebSocketTransport2.default.check(BRIDGE_URL, TRANSPORT_CHECK_DELAY).catch(async function () {
                         window.open('ledgerlive://bridge?appName=Ethereum');
                         await _this3.checkTransportLoop();
                         _this3.transport = await _WebSocketTransport2.default.open(BRIDGE_URL);

--- a/ledger-bridge.js
+++ b/ledger-bridge.js
@@ -53,14 +53,9 @@ export default class LedgerBridge {
         window.parent.postMessage(msg, '*')
     }
 
-    delay (ms) {
-        return new Promise((success) => setTimeout(success, ms))
-    }
-
     checkTransportLoop (i) {
         const iterator = i || 0
-        return WebSocketTransport.check(BRIDGE_URL).catch(async () => {
-            await this.delay(TRANSPORT_CHECK_DELAY)
+        return WebSocketTransport.check(BRIDGE_URL, TRANSPORT_CHECK_DELAY).catch(async () => {
             if (iterator < TRANSPORT_CHECK_LIMIT) {
                 return this.checkTransportLoop(iterator + 1)
             } else {
@@ -72,7 +67,7 @@ export default class LedgerBridge {
     async makeApp () {
         try {
             if (this.useLedgerLive) {
-                await WebSocketTransport.check(BRIDGE_URL).catch(async () => {
+                await WebSocketTransport.check(BRIDGE_URL, TRANSPORT_CHECK_DELAY).catch(async () => {
                     window.open('ledgerlive://bridge?appName=Ethereum')
                     await this.checkTransportLoop()
                     this.transport = await WebSocketTransport.open(BRIDGE_URL)


### PR DESCRIPTION
We presently use polling when connecting to LedgerLive so that we can time out after a given wait.  @tmashuang mentioned he didn't get the timeout after the given wait, and I've discovered that it's due to Ledger having their own wait as well:

https://github.com/LedgerHQ/ledgerjs/blob/a5c2ea85a37e00fc805c878bd428a20ab0c0206a/packages/hw-transport-http/src/WebSocketTransport.js#L21

Thus, we can pass in the desired delay interval and remove our own.