### PR TITLE
Restore Polling Delay for Ledger Live Socket Connection

### DIFF
--- a/bundle.js
+++ b/bundle.js
@@ -31,8 +31,8 @@ require('buffer');
 var BRIDGE_URL = 'ws://localhost:8435';
 
 // Number of seconds to poll for Ledger Live and Ethereum app opening
-var TRANSPORT_CHECK_LIMIT = 180;
 var TRANSPORT_CHECK_DELAY = 1000;
+var TRANSPORT_CHECK_LIMIT = 120;
 
 var LedgerBridge = function () {
     function LedgerBridge() {
@@ -84,12 +84,20 @@ var LedgerBridge = function () {
             window.parent.postMessage(msg, '*');
         }
     }, {
+        key: 'delay',
+        value: function delay(ms) {
+            return new Promise(function (success) {
+                return setTimeout(success, ms);
+            });
+        }
+    }, {
         key: 'checkTransportLoop',
         value: function checkTransportLoop(i) {
             var _this2 = this;
 
             var iterator = i || 0;
-            return _WebSocketTransport2.default.check(BRIDGE_URL, TRANSPORT_CHECK_DELAY).catch(async function () {
+            return _WebSocketTransport2.default.check(BRIDGE_URL).catch(async function () {
+                await _this2.delay(TRANSPORT_CHECK_DELAY);
                 if (iterator < TRANSPORT_CHECK_LIMIT) {
                     return _this2.checkTransportLoop(iterator + 1);
                 } else {
@@ -104,7 +112,7 @@ var LedgerBridge = function () {
                 if (this.useLedgerLive) {
                     var reestablish = false;
                     try {
-                        await _WebSocketTransport2.default.check(BRIDGE_URL, TRANSPORT_CHECK_DELAY);
+                        await _WebSocketTransport2.default.check(BRIDGE_URL);
                     } catch (_err) {
                         window.open('ledgerlive://bridge?appName=Ethereum');
                         await this.checkTransportLoop();


### PR DESCRIPTION
In https://github.com/MetaMask/eth-ledger-bridge-keyring/commit/ac5dde210eb327bdf7a7663ef7edfaf4bd316710 I aimed to remove our own delay, thinking that the `WebSocketTransport` was also instituting their own polling delay.  The more I tested today, the more variable timing I saw in iterations.

In this PR, I'm restoring the delay so that the user has a reliable amount of time, 2 minutes, for which they can (1) open Ledger Live app, (2) put in their password, (3) unlock their ledger, and (4) take their desired action.

Through testing with this PR, Ledger Live is _much_ easier to use and _more_ reliable -- a minimum of 2 minutes to get it all done.  This restores the PR to its better functional usability.