### PR TITLE
Ensure `this.app` gets constructed if transport check succeeds

### DIFF
--- a/bundle.js
+++ b/bundle.js
@@ -100,16 +100,20 @@ var LedgerBridge = function () {
     }, {
         key: 'makeApp',
         value: async function makeApp() {
-            var _this3 = this;
-
             try {
                 if (this.useLedgerLive) {
-                    await _WebSocketTransport2.default.check(BRIDGE_URL, TRANSPORT_CHECK_DELAY).catch(async function () {
+                    var reestablish = false;
+                    try {
+                        await _WebSocketTransport2.default.check(BRIDGE_URL, TRANSPORT_CHECK_DELAY);
+                    } catch (_err) {
                         window.open('ledgerlive://bridge?appName=Ethereum');
-                        await _this3.checkTransportLoop();
-                        _this3.transport = await _WebSocketTransport2.default.open(BRIDGE_URL);
-                        _this3.app = new _hwAppEth2.default(_this3.transport);
-                    });
+                        await this.checkTransportLoop();
+                        reestablish = true;
+                    }
+                    if (!this.app || reestablish) {
+                        this.transport = await _WebSocketTransport2.default.open(BRIDGE_URL);
+                        this.app = new _hwAppEth2.default(this.transport);
+                    }
                 } else {
                     this.transport = await _hwTransportU2f2.default.create();
                     this.app = new _hwAppEth2.default(this.transport);

--- a/ledger-bridge.js
+++ b/ledger-bridge.js
@@ -67,12 +67,18 @@ export default class LedgerBridge {
     async makeApp () {
         try {
             if (this.useLedgerLive) {
-                await WebSocketTransport.check(BRIDGE_URL, TRANSPORT_CHECK_DELAY).catch(async () => {
+                let reestablish = false;
+                try {
+                    await WebSocketTransport.check(BRIDGE_URL, TRANSPORT_CHECK_DELAY)
+                } catch (_err) {
                     window.open('ledgerlive://bridge?appName=Ethereum')
                     await this.checkTransportLoop()
+                    reestablish = true;
+                }
+                if (!this.app || reestablish) {
                     this.transport = await WebSocketTransport.open(BRIDGE_URL)
                     this.app = new LedgerEth(this.transport)
-                })
+                }
             }
             else {
                 this.transport = await TransportU2F.create()


### PR DESCRIPTION
Previously `this.app` would only get constructed if the transport check failed. This relied upon the assumption that the transport would not work if it hadn't been established yet. However the transport check can succeed the first time if using Ledger Live, if the bridge to Ledger Live has already been established.

`this.app` is now always constructed in `makeApp` if it's falsy. The `reestablish` boolean is used to ensure we don't needlessly construct `this.app` every time `makeApp` is called - we only re-construct it if the connection was dropped and had to be re-established.