### PR TITLE
More fix 1559

### DIFF
--- a/index.js
+++ b/index.js
@@ -245,6 +245,7 @@ class LedgerBridgeKeyring extends EventEmitter {
       // represents the transaction. Using txData here as it aligns with the
       // nomenclature of ethereumjs/tx.
       const txData = tx.toJSON()
+      txData.type = tx.type;
       // The fromTxData utility expects v,r and s to be hex prefixed
       txData.v = ethUtil.addHexPrefix(payload.v)
       txData.r = ethUtil.addHexPrefix(payload.r)

--- a/index.js
+++ b/index.js
@@ -257,13 +257,19 @@ class LedgerBridgeKeyring extends EventEmitter {
   }
 
   _signTransaction (address, tx, toAddress, handleSigning) {
+
     return new Promise((resolve, reject) => {
       this.unlockAccountByAddress(address)
         .then((hdPath) => {
+          const rawTx = tx.raw()
+          const rawTxVRSRemoved = rawTx.slice(0, rawTx.length - 3)
+          const serializedUntypedTx = ethUtil.rlp.encode(rawTxVRSRemoved)
+          const serializedUntypedTxString = serializedUntypedTx.toString('hex')
+          const serializedTypedTx = '02' + serializedUntypedTxString
           this._sendMessage({
             action: 'ledger-sign-transaction',
             params: {
-              tx: tx.serialize().toString('hex'),
+              tx: serializedTypedTx,
               hdPath,
               to: ethUtil.bufferToHex(toAddress).toLowerCase(),
             },

--- a/index.js
+++ b/index.js
@@ -244,6 +244,13 @@ class LedgerBridgeKeyring extends EventEmitter {
       })
     }
 
+    // Note the below `encode`` call is only necessary for legacy transactions, as `getMessageToSign`
+    // returns a serialized value. However, calling rlp.encode on such a value will return an identical
+    // value. As such, the below call handles both legacy and non-legacy transactions from ethereumjs-tx
+
+    // Note also that `getMessageToSign` will return valid RLP for all transaction types, whereas the
+    // `serialize` method will not for any transaction type except legacy. This is because serialize includes
+    // empty r, s and v values in the encoded rlp.
     rawTxHex = ethUtil.rlp.encode(tx.getMessageToSign(false)).toString('hex')
 
     return this._signTransaction(address, rawTxHex, tx.to.buf, (payload) => {

--- a/test/test-eth-ledger-bridge-keyring.js
+++ b/test/test-eth-ledger-bridge-keyring.js
@@ -472,7 +472,7 @@ describe('LedgerBridgeKeyring', function () {
           assert.deepStrictEqual(msg.params, {
             hdPath: "m/44'/60'/0'/0",
             to: ethUtil.bufferToHex(newFakeTx.to.buf),
-            tx: newFakeTx.serialize().toString('hex'),
+            tx: ethUtil.rlp.encode(newFakeTx.getMessageToSign(false)).toString('hex'),
           })
           cb({ success: true, payload: { v: '0x25', r: '0x0', s: '0x0' } })
         })


### PR DESCRIPTION
Compares against https://github.com/MetaMask/eth-ledger-bridge-keyring/pull/93 and truly gets ledger working for EIP-1559 transactions.

Includes two parts:
(1) Adding missing type data to the object we pass to ethereumjs-tx, so that it can correctly identify the need to create an EIP-1559 compatible transaction
(2) A workaround for a yet to be identified bug somewhere in our stack involved in ledger transactions... probably in a ledger library itself or in a misunderstanding of requirements of the ledger api

Further explanation of how I came to the workaround (the change on lines 264-268):

- I identified the need for part (1) f this PR (the change on line 248) [two days ago](https://github.com/MetaMask/eth-ledger-bridge-keyring/pull/93#discussion_r692075655)
- However, even with that change there was a very strange failure happening: when the ledger would sign the transaction, the resulting signatures would not be associated with with the ledger wallet... it was as if they were signed by a another address. The user facing error was a failure message that the account did not have balance for value + gas fee. That is because the rawTx generated after signing contained a different `from` address than the public address of the account that did the signing. Or, more formally, doing a recovery on r, s and v values generated by signing would result in a different address than the hardware wallet address we attempted to sign with
- Meanwhile, attempting to send an identical transaction with the same ledger and account using the MyCrypto integration was successful
- Investigation revealed that while MyCrypto is using the same ledger libraries and versions as we are here, and seemingly passing the same time of data to the same methods, there is a difference between our implementations. MyCrypto is using ethers.js to serialize and generate the raw tx data to be signed, while we are using ethereumjs-tx
- There is a difference between how ethers.js and ethereumjs-tx serializes transactions: ethereumjs-tx includes the undefined r, s and v values when RLP encoding the transaction, while ethers.js does not. So the given the follow transaction:
```
{
  "gasLimit": "0x5208",
  "nonce": "0x0",
  "to": "0xe18035bf8712672935fdb4e5e431b1a0183d2dfc",
  "value": "0x0",
  "maxFeePerGas": "0x59682f0e",
  "maxPriorityFeePerGas": "0x59682f00",
  "chainId": "0x4",
  "accessList": []
  "type": 2
}
```
ethers.js will serialize as `02e704808459682f008459682f0e82520894e18035bf8712672935fdb4e5e431b1a0183d2dfc8080c0` but ethereumjs-tx will serialize as `02ea04808459682f008459682f0e82520894e18035bf8712672935fdb4e5e431b1a0183d2dfc8080c0808080` 

- For some yet unknown reason, ledger - in particular ` @ledgerhq/hw-app-eth` - will produce to different signatures for these two different serializations when using the same ledger and account address. This is unexpected because if we use the private key for that ledger managed address, ethereumjs-tx's signing will produce the exact same signature for both of the above serializations
- A note that may have some importantance: ethers.js and ethereumjs-tx serialize legacy transactions in a much more similar way, in particular there is just a 1 byte difference (seemingly to do with the chainid, in the third to last part of the RLP encoding of the transaction) but they have the same length. This similarity is due to that fact that for legacy transactions, the undefined r, s and v values are included in the RLP encoding in ethers.js. ` @ledgerhq/hw-app-eth` signs both of these transactions in the same way, and so legacy transactions can be successfully sent via our ledger integration
- Based on these findings and some other investigation into the ` @ledgerhq/hw-app-eth` codebase, my current leading suspicion is that it is the difference in lengths of the different serializations of the transaction that causes a different result from ledger. Of note hear is the use of `data.length` in construction of the buffered data that is ultimately used in creating the signature: https://github.com/LedgerHQ/ledgerjs/blob/master/packages/hw-transport/src/Transport.ts#L204-L210 . This construction bears similarity with the way that web3 documentation describes the calculation of ethereum specific signatures: https://web3js.readthedocs.io/en/v1.2.9/web3-eth-personal.html?highlight=sign#sign . This guess (that the length of the serialized tx can result in a flawed signature) remains a speculation on my part. I have not been able to verify. We might be able to confirm this by asking the ledger team. Also I have not yet thoroughly inspected their docs to see if there is any info relevant to this.
- The _workaround_ to this problem that I have implemented in this PR simply removes the undefined r, s and v parts from the `rawTx` before it is RLP encoded. This allows us to successfully send EIP-1559 transactions on ledger in MetaMask. This works because, as mentioned above, the signing of the transaction _should_ produce the same result whether or not these are included. ethereumjs-tx will produce the same signature for both cases. Also, as mentioned above, transactions encoded/serialized by ethers.js work without these parts being included. And I believe this is supported by figure 305 on page 25 of this version of the ethereum yellow paper (https://ethereum.github.io/yellowpaper/paper.pdf)
- More concretely on this workaround, my added code does the same thing that `tx.serialize()` does internally, except that the last three items are removed from the `rawTx` before rlp encoding. You can see the implementation of serialize here https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/eip1559Transaction.ts#L289, and the content of the `rawTx` list can be understood here https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/eip1559Transaction.ts#L263

So I believe the workaround is correct, but it would be nice to understand the nature of the signing bug that necessitated it before we merge and ship. If we can verify either a bug or an undocumented api expectation that explains this, then I think we can ship the workaround. We should look for that explanation either from the ledger team directly, from somewhere in documentaiton, or in the source code.

two other to do items:

- [ ] Only apply the workaround to EIP-1559 transactions, not legacy (some simple if/then logic will suffice)
- [ ] Update unit tests (and fix lint)