### PR TITLE
Fix 1559

### DIFF
--- a/index.js
+++ b/index.js
@@ -219,6 +219,7 @@ class LedgerBridgeKeyring extends EventEmitter {
 
   // tx is an instance of the ethereumjs-transaction class.
   signTransaction (address, tx) {
+    let rawTxHex
     // transactions built with older versions of ethereumjs-tx have a
     // getChainId method that newer versions do not. Older versions are mutable
     // while newer versions default to being immutable. Expected shape and type
@@ -232,7 +233,10 @@ class LedgerBridgeKeyring extends EventEmitter {
       tx.v = ethUtil.bufferToHex(tx.getChainId())
       tx.r = '0x00'
       tx.s = '0x00'
-      return this._signTransaction(address, tx, tx.to, (payload) => {
+
+      rawTxHex = tx.serialize().toString('hex')
+
+      return this._signTransaction(address, rawTxHex, tx.to, (payload) => {
         tx.v = Buffer.from(payload.v, 'hex')
         tx.r = Buffer.from(payload.r, 'hex')
         tx.s = Buffer.from(payload.s, 'hex')
@@ -240,11 +244,22 @@ class LedgerBridgeKeyring extends EventEmitter {
       })
     }
 
-    return this._signTransaction(address, tx, tx.to.buf, (payload) => {
+    // Note the below `encode`` call is only necessary for legacy transactions, as `getMessageToSign`
+    // returns a serialized value. However, calling rlp.encode on such a value will return an identical
+    // value. As such, the below call handles both legacy and non-legacy transactions from ethereumjs-tx
+
+    // Note also that `getMessageToSign` will return valid RLP for all transaction types, whereas the
+    // `serialize` method will not for any transaction type except legacy. This is because serialize includes
+    // empty r, s and v values in the encoded rlp.
+    rawTxHex = ethUtil.rlp.encode(tx.getMessageToSign(false)).toString('hex')
+
+    return this._signTransaction(address, rawTxHex, tx.to.buf, (payload) => {
       // Because tx will be immutable, first get a plain javascript object that
       // represents the transaction. Using txData here as it aligns with the
       // nomenclature of ethereumjs/tx.
       const txData = tx.toJSON()
+      // The fromTxData utility expects a type to support transactions with a type other than 0
+      txData.type = tx.type
       // The fromTxData utility expects v,r and s to be hex prefixed
       txData.v = ethUtil.addHexPrefix(payload.v)
       txData.r = ethUtil.addHexPrefix(payload.r)
@@ -255,14 +270,15 @@ class LedgerBridgeKeyring extends EventEmitter {
     })
   }
 
-  _signTransaction (address, tx, toAddress, handleSigning) {
+  _signTransaction (address, rawTxHex, toAddress, handleSigning) {
+
     return new Promise((resolve, reject) => {
       this.unlockAccountByAddress(address)
         .then((hdPath) => {
           this._sendMessage({
             action: 'ledger-sign-transaction',
             params: {
-              tx: tx.serialize().toString('hex'),
+              tx: rawTxHex,
               hdPath,
               to: ethUtil.bufferToHex(toAddress).toLowerCase(),
             },

--- a/index.js
+++ b/index.js
@@ -239,18 +239,8 @@ class LedgerBridgeKeyring extends EventEmitter {
         return tx
       })
     }
-    // For transactions created by newer versions of @ethereumjs/tx
-    // Note: https://github.com/ethereumjs/ethereumjs-monorepo/issues/1188
-    // It is not strictly necessary to do this additional setting of the v
-    // value. We should be able to get the correct v value in serialization
-    // if the above issue is resolved. Until then this must be set before
-    // calling .serialize(). Note we are creating a temporarily mutable object
-    // forfeiting the benefit of immutability until this happens. We do still
-    // return a Transaction that is frozen if the originally provided
-    // transaction was also frozen.
-    const unfrozenTx = TransactionFactory.fromTxData(tx.toJSON(), { common: tx.common, freeze: false })
-    unfrozenTx.v = new ethUtil.BN(ethUtil.addHexPrefix(tx.common.chainId()), 'hex')
-    return this._signTransaction(address, unfrozenTx, tx.to.buf, (payload) => {
+    
+    return this._signTransaction(address, tx, tx.to.buf, (payload) => {
       // Because tx will be immutable, first get a plain javascript object that
       // represents the transaction. Using txData here as it aligns with the
       // nomenclature of ethereumjs/tx.

--- a/index.js
+++ b/index.js
@@ -239,7 +239,7 @@ class LedgerBridgeKeyring extends EventEmitter {
         return tx
       })
     }
-    
+
     return this._signTransaction(address, tx, tx.to.buf, (payload) => {
       // Because tx will be immutable, first get a plain javascript object that
       // represents the transaction. Using txData here as it aligns with the

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   },
   "dependencies": {
     "eth-sig-util": "^2.0.0",
-    "@ethereumjs/tx": "^3.1.1",
+    "@ethereumjs/tx": "^3.1.4",
     "ethereumjs-tx": "^1.3.4",
     "ethereumjs-util": "^7.0.9",
     "events": "^2.0.0",

--- a/test/test-eth-ledger-bridge-keyring.js
+++ b/test/test-eth-ledger-bridge-keyring.js
@@ -472,7 +472,7 @@ describe('LedgerBridgeKeyring', function () {
           assert.deepStrictEqual(msg.params, {
             hdPath: "m/44'/60'/0'/0",
             to: ethUtil.bufferToHex(newFakeTx.to.buf),
-            tx: newFakeTx.serialize().toString('hex'),
+            tx: ethUtil.rlp.encode(newFakeTx.getMessageToSign(false)).toString('hex'),
           })
           cb({ success: true, payload: { v: '0x25', r: '0x0', s: '0x0' } })
         })

--- a/yarn.lock
+++ b/yarn.lock
@@ -117,13 +117,21 @@
     crc-32 "^1.2.0"
     ethereumjs-util "^7.0.9"
 
-"@ethereumjs/tx@^3.1.1":
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/@ethereumjs/tx/-/tx-3.1.1.tgz#e8d6943baa955b2d197d2f6f7864939991b8feb3"
-  integrity sha512-IuN9EUT6sCZrldVbgQA+XuuxouUvMdoW34qZvlzFtCgjlvKJ848iK/lDTJVVPNb3WndlEu3d2a7Mu474ggdT/g==
+"@ethereumjs/common@^2.4.0":
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/@ethereumjs/common/-/common-2.4.0.tgz#2d67f6e6ba22246c5c89104e6b9a119fb3039766"
+  integrity sha512-UdkhFWzWcJCZVsj1O/H8/oqj/0RVYjLc1OhPjBrQdALAkQHpCp8xXI4WLnuGTADqTdJZww0NtgwG+TRPkXt27w==
   dependencies:
-    "@ethereumjs/common" "^2.2.0"
-    ethereumjs-util "^7.0.9"
+    crc-32 "^1.2.0"
+    ethereumjs-util "^7.1.0"
+
+"@ethereumjs/tx@^3.1.4":
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/@ethereumjs/tx/-/tx-3.3.0.tgz#14ed1b7fa0f28e1cd61e3ecbdab824205f6a4378"
+  integrity sha512-yTwEj2lVzSMgE6Hjw9Oa1DZks/nKTWM8Wn4ykDNapBPua2f4nXO3qKnni86O6lgDj5fVNRqbDsD0yy7/XNGDEA==
+  dependencies:
+    "@ethereumjs/common" "^2.4.0"
+    ethereumjs-util "^7.1.0"
 
 "@metamask/eslint-config@^3.0.0":
   version "3.2.0"
@@ -906,6 +914,18 @@ ethereumjs-util@^7.0.9:
   version "7.0.9"
   resolved "https://registry.yarnpkg.com/ethereumjs-util/-/ethereumjs-util-7.0.9.tgz#2038baeb30f370a3e576ec175bd70bbbb6807d42"
   integrity sha512-cRqvYYKJoitq6vMKMf8pXeVwvTrX+dRD0JwHaYqm8jvogK14tqIoCWH/KUHcRwnVxVXEYF/o6pup5jRG4V0xzg==
+  dependencies:
+    "@types/bn.js" "^5.1.0"
+    bn.js "^5.1.2"
+    create-hash "^1.1.2"
+    ethereum-cryptography "^0.1.3"
+    ethjs-util "0.1.6"
+    rlp "^2.2.4"
+
+ethereumjs-util@^7.1.0:
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/ethereumjs-util/-/ethereumjs-util-7.1.0.tgz#e2b43a30bfcdbcb432a4eb42bd5f2393209b3fd5"
+  integrity sha512-kR+vhu++mUDARrsMMhsjjzPduRVAeundLGXucGRHF3B4oEltOUspfgCVco4kckucj3FMlLaZHUl9n7/kdmr6Tw==
   dependencies:
     "@types/bn.js" "^5.1.0"
     bn.js "^5.1.2"


### PR DESCRIPTION
This PR updates eth-ledger-bridge-keyring to support EIP-1559 transactions.

The following changes are made:

- transactions that are created by the latest version of ethereumjs-tx use the `getMessageToSign` method instead of `serialize` to get the tx data for serialization. `getMessageToSign` returns the correct raw data for non-legacy transactions, whereas `serialize` only works for legacy transactions. This is explained in discussion on #96
- the `txData` passed to `TransactionFactory.fromTxData` is assigned a `type` property, so that `fromTxData` can create the correct type of transaction
- package.json is updated to ensure we get the fix that removes the need for the code here https://github.com/MetaMask/eth-ledger-bridge-keyring/compare/fix-1559?expand=1#diff-e727e4bdf3657fd1d798edcd6b099d6e092f8573cba266154583a746bba0f346L242-L253

This PR replaces #93 