### PR TITLE
Safe property access / allow transaction with undefined to fields, in signTransaction

### DIFF
--- a/index.js
+++ b/index.js
@@ -236,7 +236,7 @@ class LedgerBridgeKeyring extends EventEmitter {
 
       rawTxHex = tx.serialize().toString('hex')
 
-      return this._signTransaction(address, rawTxHex, tx.to, (payload) => {
+      return this._signTransaction(address, rawTxHex, (payload) => {
         tx.v = Buffer.from(payload.v, 'hex')
         tx.r = Buffer.from(payload.r, 'hex')
         tx.s = Buffer.from(payload.s, 'hex')
@@ -256,7 +256,7 @@ class LedgerBridgeKeyring extends EventEmitter {
       ? ethUtil.rlp.encode(tx.getMessageToSign(false)).toString('hex')
       : tx.getMessageToSign(false).toString('hex')
 
-    return this._signTransaction(address, rawTxHex, tx.to.buf, (payload) => {
+    return this._signTransaction(address, rawTxHex, (payload) => {
       // Because tx will be immutable, first get a plain javascript object that
       // represents the transaction. Using txData here as it aligns with the
       // nomenclature of ethereumjs/tx.
@@ -273,7 +273,7 @@ class LedgerBridgeKeyring extends EventEmitter {
     })
   }
 
-  _signTransaction (address, rawTxHex, toAddress, handleSigning) {
+  _signTransaction (address, rawTxHex, handleSigning) {
 
     return new Promise((resolve, reject) => {
       this.unlockAccountByAddress(address)
@@ -283,7 +283,6 @@ class LedgerBridgeKeyring extends EventEmitter {
             params: {
               tx: rawTxHex,
               hdPath,
-              to: ethUtil.bufferToHex(toAddress).toLowerCase(),
             },
           },
           ({ success, payload }) => {

--- a/test/test-eth-ledger-bridge-keyring.js
+++ b/test/test-eth-ledger-bridge-keyring.js
@@ -440,7 +440,6 @@ describe('LedgerBridgeKeyring', function () {
         sandbox.on(keyring, '_sendMessage', (msg, cb) => {
           assert.deepStrictEqual(msg.params, {
             hdPath: "m/44'/60'/0'/0",
-            to: ethUtil.bufferToHex(fakeTx.to),
             tx: fakeTx.serialize().toString('hex'),
           })
           cb({ success: true, payload: { v: '0x1', r: '0x0', s: '0x0' } })
@@ -471,7 +470,6 @@ describe('LedgerBridgeKeyring', function () {
         sandbox.on(keyring, '_sendMessage', (msg, cb) => {
           assert.deepStrictEqual(msg.params, {
             hdPath: "m/44'/60'/0'/0",
-            to: ethUtil.bufferToHex(newFakeTx.to.buf),
             tx: ethUtil.rlp.encode(newFakeTx.getMessageToSign(false)).toString('hex'),
           })
           cb({ success: true, payload: { v: '0x25', r: '0x0', s: '0x0' } })


### PR DESCRIPTION
With https://github.com/MetaMask/eth-ledger-bridge-keyring/pull/68, we started directly accessing a `.buf` property on `tx.to` in `signTransaction`. This was necessary given changes in ethereumjs-tx

The problem is that the `to` field can be undefined. This is necessary for deploying contracts. Currently, in prod, if you attempt to create a contract deployment transaction with ledger in metamask, you will see an error because of `tx.to.buf` and `tx.to` being undefined.

This PR fixes that.