### PR TITLE
v0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.7.0]
 ### Changed
-- Remove unused events dependency ([#102](https://github.com/MetaMask/eth-ledger-bridge-keyring/pull/102))
+- Remove unused `events` and `ethereumjs-tx` dependencies ([#101](https://github.com/MetaMask/eth-ledger-bridge-keyring/pull/101), [#102](https://github.com/MetaMask/eth-ledger-bridge-keyring/pull/102))
 - Update eth-ledger-bridge-keyring to support EIP-1559 transactions ([#98](https://github.com/MetaMask/eth-ledger-bridge-keyring/pull/98), [#97](https://github.com/MetaMask/eth-ledger-bridge-keyring/pull/97), [#96](https://github.com/MetaMask/eth-ledger-bridge-keyring/pull/96))
 
 ## [0.6.0]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # Changelog
+
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
@@ -6,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.0]
+
+- Allow transaction with undefined 'to' fields, in signTransaction ([#98](https://github.com/MetaMask/eth-ledger-bridge-keyring/pull/98))
+- Update eth-ledger-bridge-keyring to support EIP-1559 transactions ([#97](https://github.com/MetaMask/eth-ledger-bridge-keyring/pull/97), [#96](https://github.com/MetaMask/eth-ledger-bridge-keyring/pull/96))
+- Update gh-pages to receive chainId, update Ledger library to 6.5.0 ([#95](https://github.com/MetaMask/eth-ledger-bridge-keyring/pull/95))
+- Bump path-parse from 1.0.6 to 1.0.7 ([#92](https://github.com/MetaMask/eth-ledger-bridge-keyring/pull/92))
+
 ## [0.6.0]
+
 ### Added
-- [#68](https://github.com/MetaMask/eth-ledger-bridge-keyring/pull/68): Support new versions of ethereumjs/tx
+
+- Support new versions of ethereumjs/tx ([#68](https://github.com/MetaMask/eth-ledger-bridge-keyring/pull/68))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,14 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ## [0.7.0]
-
-- Allow transaction with undefined 'to' fields, in signTransaction ([#98](https://github.com/MetaMask/eth-ledger-bridge-keyring/pull/98))
-- Update eth-ledger-bridge-keyring to support EIP-1559 transactions ([#97](https://github.com/MetaMask/eth-ledger-bridge-keyring/pull/97), [#96](https://github.com/MetaMask/eth-ledger-bridge-keyring/pull/96))
-- Update gh-pages to receive chainId, update Ledger library to 6.5.0 ([#95](https://github.com/MetaMask/eth-ledger-bridge-keyring/pull/95))
-- Bump path-parse from 1.0.6 to 1.0.7 ([#92](https://github.com/MetaMask/eth-ledger-bridge-keyring/pull/92))
+### Changed
+- Update eth-ledger-bridge-keyring to support EIP-1559 transactions ([#98](https://github.com/MetaMask/eth-ledger-bridge-keyring/pull/98), [#97](https://github.com/MetaMask/eth-ledger-bridge-keyring/pull/97), [#96](https://github.com/MetaMask/eth-ledger-bridge-keyring/pull/96))
 
 ## [0.6.0]
-
 ### Added
-
 - Support new versions of ethereumjs/tx ([#68](https://github.com/MetaMask/eth-ledger-bridge-keyring/pull/68))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.7.0]
 ### Changed
+- Remove unused events dependency ([#102](https://github.com/MetaMask/eth-ledger-bridge-keyring/pull/102))
 - Update eth-ledger-bridge-keyring to support EIP-1559 transactions ([#98](https://github.com/MetaMask/eth-ledger-bridge-keyring/pull/98), [#97](https://github.com/MetaMask/eth-ledger-bridge-keyring/pull/97), [#96](https://github.com/MetaMask/eth-ledger-bridge-keyring/pull/96))
 
 ## [0.6.0]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/eth-ledger-bridge-keyring",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "A MetaMask compatible keyring, for ledger hardware wallets",
   "main": "index.js",
   "files": [


### PR DESCRIPTION
## [0.7.0]
### Changed
- Update eth-ledger-bridge-keyring to support EIP-1559 transactions ([#98](https://github.com/MetaMask/eth-ledger-bridge-keyring/pull/98), [#97](https://github.com/MetaMask/eth-ledger-bridge-keyring/pull/97), [#96](https://github.com/MetaMask/eth-ledger-bridge-keyring/pull/96))