### PR TITLE
Move `ethereumjs-tx` to the `devDependencies`

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
   "dependencies": {
     "eth-sig-util": "^2.0.0",
     "@ethereumjs/tx": "^3.2.0",
-    "ethereumjs-tx": "^1.3.4",
     "ethereumjs-util": "^7.0.9",
     "events": "^2.0.0",
     "hdkey": "0.8.0"
@@ -55,6 +54,7 @@
     "eslint-plugin-import": "^2.20.1",
     "eslint-plugin-json": "^1.2.0",
     "eslint-plugin-mocha": "^6.2.2",
+    "ethereumjs-tx": "^1.3.4",
     "mocha": "^5.0.4"
   }
 }


### PR DESCRIPTION
The `ethereumjs-tx` package is now only used in the unit tests, for ensuring compatibility with that older package. The published code uses the successor package `@ethereumjs/tx`.