### PR TITLE
Remove unused `events` dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,6 @@
     "@ethereumjs/tx": "^3.2.0",
     "ethereumjs-tx": "^1.3.4",
     "ethereumjs-util": "^7.0.9",
-    "events": "^2.0.0",
     "hdkey": "0.8.0"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -934,11 +934,6 @@ ethjs-util@0.1.6, ethjs-util@^0.1.3:
     is-hex-prefixed "1.0.0"
     strip-hex-prefix "1.0.0"
 
-events@^2.0.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/events/-/events-2.1.0.tgz#2a9a1e18e6106e0e812aa9ebd4a819b3c29c0ba5"
-  integrity sha512-3Zmiobend8P9DjmKAty0Era4jV8oJ0yGYe2nJJAxgymF9+N8F2m0hhZiMoWtcfepExzNKZumFU3ksdQbInGWCg==
-
 evp_bytestokey@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz#7fcbdb198dc71959432efe13842684e0525acb02"


### PR DESCRIPTION
The `events` package was listed as a dependency despite not being used. We do import from `events`, but this is the built-in Node.js events API, which takes precedent over packages.