### PR TITLE
Display message inside Ledger contract data error

### DIFF
--- a/index.js
+++ b/index.js
@@ -297,7 +297,7 @@ class LedgerBridgeKeyring extends EventEmitter {
                 reject(new Error('Ledger: The transaction signature is not valid'))
               }
             } else {
-              reject(payload.error || new Error('Ledger: Unknown error while signing transaction'))
+              reject(payload.error.message || new Error('Ledger: Unknown error while signing transaction'))
             }
           })
         })


### PR DESCRIPTION
Before this patch, when a user has contract data/blind sign disabled in the Ledger Ethereum app and tries to sign a smart contract transaction on Metamask, a weird error is displayed:
![Screenshot_20211001_100429--00001](https://user-images.githubusercontent.com/10632523/135619342-965acd7a-44c4-45de-9401-53c4f5a7964f.png)

This PR fixes it:
![Screenshot_20211001_134249--00001](https://user-images.githubusercontent.com/10632523/135619424-7dd323f2-eff6-402a-8667-9a1ebdadf0c4.png)

