### PR TITLE
Pass through option to use webhid to ledger bridge

### DIFF
--- a/index.js
+++ b/index.js
@@ -432,7 +432,7 @@ class LedgerBridgeKeyring extends EventEmitter {
       if (this.delayedPromise) {
         try {
           const result = await this.updateTransportMethod(
-            this.delayedPromise.transportType
+            this.delayedPromise.transportType,
           )
           this.delayedPromise.resolve(result)
         } catch (e) {


### PR DESCRIPTION
This PR changes the variable name and default value for the parameter that is received by `updateTransportMethod` and send on to the bridge.

This allows us to set the transport preference property as an enum, thereby supporting the setting of different preferences than just a boolean setting on ledger live.