### PR TITLE
Use this.transportType for cleanup check

### DIFF
--- a/bundle.js
+++ b/bundle.js
@@ -185,7 +185,7 @@ var LedgerBridge = function () {
                     payload: { error: e }
                 });
             } finally {
-                if (!this.useLedgerLive) {
+                if (this.transportType !== 'ledgerLive') {
                     this.cleanUp();
                 }
             }
@@ -209,7 +209,7 @@ var LedgerBridge = function () {
                     payload: { error: e }
                 });
             } finally {
-                if (!this.useLedgerLive) {
+                if (this.transportType !== 'ledgerLive') {
                     this.cleanUp();
                 }
             }
@@ -234,7 +234,7 @@ var LedgerBridge = function () {
                     payload: { error: e }
                 });
             } finally {
-                if (!this.useLedgerLive) {
+                if (this.transportType !== 'ledgerLive') {
                     this.cleanUp();
                 }
             }

--- a/ledger-bridge.js
+++ b/ledger-bridge.js
@@ -142,7 +142,7 @@ export default class LedgerBridge {
                 payload: { error: e },
             })
         } finally {
-            if (!this.useLedgerLive) {
+            if (this.transportType !== 'ledgerLive') {
                 this.cleanUp()
             }
         }
@@ -167,7 +167,7 @@ export default class LedgerBridge {
             })
 
         } finally {
-            if (!this.useLedgerLive) {
+            if (this.transportType !== 'ledgerLive') {
                 this.cleanUp()
             }
         }
@@ -192,7 +192,7 @@ export default class LedgerBridge {
             })
 
         } finally {
-            if (!this.useLedgerLive) {
+            if (this.transportType !== 'ledgerLive') {
                 this.cleanUp()
             }
         }


### PR DESCRIPTION
This fixes a bug found by @darkwing while QAing the gh-pages-staging branch

There were some instances of this.useLedgerLive that should have been updated in #113 