### PR TITLE
Allow the triggering of make-app via message

### DIFF
--- a/bundle.js
+++ b/bundle.js
@@ -137,8 +137,9 @@ var LedgerBridge = function () {
         }
     }, {
         key: 'makeApp',
-        value: async function makeApp(config) {
-            config = config || {};
+        value: async function makeApp() {
+            var config = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {};
+
             try {
                 if (this.transportType === 'ledgerLive') {
                     var reestablish = false;

--- a/ledger-bridge.js
+++ b/ledger-bridge.js
@@ -96,8 +96,7 @@ export default class LedgerBridge {
         }
     }
 
-    async makeApp (config) {
-        config = config || {};
+    async makeApp (config = {}) {
         try {
             if (this.transportType === 'ledgerLive') {
                 let reestablish = false;


### PR DESCRIPTION
This PR does two things:

1. Adds a handle for a `'ledger-make-app'` message, which calls a new wrapper around the `makeApp` method. This allows external callers to attempt to create a transport and device connection and then see whether that attempt succeeded or failed, decoupled from any action.
2. Ensures that no unnecessary attempt to connect the ledger device via webhid is made if a webhid transport already exists and is open