### PR TITLE
Add method to request the bridge to create the ledger transport

### DIFF
--- a/index.js
+++ b/index.js
@@ -191,6 +191,20 @@ class LedgerBridgeKeyring extends EventEmitter {
     delete this.accountDetails[ethUtil.toChecksumAddress(address)]
   }
 
+  attemptMakeApp () {
+    return new Promise((resolve, reject) => {
+      this._sendMessage({
+        action: 'ledger-make-app',
+      }, ({ success, error }) => {
+        if (success) {
+          resolve(true)
+        } else {
+          reject(error)
+        }
+      })
+    })
+  }
+
   updateTransportMethod (transportType) {
     return new Promise((resolve, reject) => {
       // If the iframe isn't loaded yet, let's store the desired transportType value and


### PR DESCRIPTION
This depends on https://github.com/MetaMask/eth-ledger-bridge-keyring/pull/125

This exposes a method which will directly, and only, create a ledger transport or return an error message if that fails.