### PR TITLE
Rewrite messaging to ensure message order is correct

### DIFF
--- a/index.js
+++ b/index.js
@@ -493,9 +493,6 @@ class LedgerBridgeKeyring extends EventEmitter {
       return undefined
     }
     window.addEventListener('message', eventListener)
-    window.addEventListener('beforeunload', () => {
-      window.removeEventListener('message', eventListener)
-    })
   }
 
   async __getPage (increment) {

--- a/index.js
+++ b/index.js
@@ -473,7 +473,7 @@ class LedgerBridgeKeyring extends EventEmitter {
   _sendMessage (msg, cb) {
     msg.target = 'LEDGER-IFRAME'
 
-    this.currentMessageId++
+    this.currentMessageId += 1
     msg.messageId = this.currentMessageId
 
     this.messageCallbacks[this.currentMessageId] = cb

--- a/index.js
+++ b/index.js
@@ -36,6 +36,9 @@ class LedgerBridgeKeyring extends EventEmitter {
 
     this.iframeLoaded = false
     this._setupIframe()
+
+    this.currentMessageId = 0
+    this.messageCallbacks = {}
   }
 
   serialize () {
@@ -455,6 +458,8 @@ class LedgerBridgeKeyring extends EventEmitter {
           delete this.delayedPromise
         }
       }
+
+      this._setupListener()
     }
     document.head.appendChild(this.iframe)
   }
@@ -467,21 +472,30 @@ class LedgerBridgeKeyring extends EventEmitter {
 
   _sendMessage (msg, cb) {
     msg.target = 'LEDGER-IFRAME'
+
+    this.currentMessageId++
+    msg.messageId = this.currentMessageId
+
+    this.messageCallbacks[this.currentMessageId] = cb
     this.iframe.contentWindow.postMessage(msg, '*')
+  }
+
+  _setupListener () {
     const eventListener = ({ origin, data }) => {
       if (origin !== this._getOrigin()) {
         return false
       }
 
-      if (data && data.action && data.action === `${msg.action}-reply` && cb) {
-        cb(data)
-        return undefined
+      if (data && this.messageCallbacks[data.messageId]) {
+        this.messageCallbacks[data.messageId](data)
       }
 
-      window.removeEventListener('message', eventListener)
       return undefined
     }
     window.addEventListener('message', eventListener)
+    window.addEventListener('beforeunload', () => {
+      window.removeEventListener('message', eventListener)
+    })
   }
 
   async __getPage (increment) {


### PR DESCRIPTION
At present, there's no guarantee that messages are received in the correct order, which is a problem.  Instead we could use an ID-based system, passing the ID back and forth from `gh-pages`.