### PR TITLE
Incorrect recovery identifier “v” when signing EIP-712 messages

### DIFF
--- a/index.js
+++ b/index.js
@@ -337,7 +337,7 @@ class LedgerBridgeKeyring extends EventEmitter {
           },
           ({ success, payload }) => {
             if (success) {
-              let v = payload.v - 27
+              let v = payload.v
               v = v.toString(16)
               if (v.length < 2) {
                 v = `0${v}`
@@ -402,7 +402,7 @@ class LedgerBridgeKeyring extends EventEmitter {
     })
 
     if (success) {
-      let v = payload.v - 27
+      let v = payload.v
       v = v.toString(16)
       if (v.length < 2) {
         v = `0${v}`


### PR DESCRIPTION
**Describe the bug**
The Ethereum YellowPaper appendix F, page 25, defines the recovery identifier “v” - the last byte of the signature. It should be either 27 (0x1b) or 28 (0x1c). Metamask signing EIP-712 messages with Ledger always returns "0" or "1"
https://ethereum.github.io/yellowpaper/paper.pdf
This causes issues on some applications which are checking for correct signature format.

**Steps to reproduce**
Sign Typed V4 or Personal message with Ledger. Check result. It will end with "0" or "1"
Sign same V4 and Personal messages with internal, non-Ledger, Metamask account. Result will end with 27 (0x1b) or 28 (0x1c).

**Expected behavior**
Signed Typed and Personal messages result should end with "0x1b" or "0x1c"