### PR TITLE
Setup message listener upon initialization

### DIFF
--- a/index.js
+++ b/index.js
@@ -39,6 +39,7 @@ class LedgerBridgeKeyring extends EventEmitter {
 
     this.currentMessageId = 0
     this.messageCallbacks = {}
+    this._setupListener()
   }
 
   serialize () {
@@ -458,8 +459,6 @@ class LedgerBridgeKeyring extends EventEmitter {
           delete this.delayedPromise
         }
       }
-
-      this._setupListener()
     }
     document.head.appendChild(this.iframe)
   }


### PR DESCRIPTION
The placement of `setupListener` is an unnecessary optimization that's causing problems at the moment.  There's no reason to wait for an iframe to load to setup the message listeners.