### PR TITLE
Add destroy method

### DIFF
--- a/index.js
+++ b/index.js
@@ -486,7 +486,7 @@ class LedgerBridgeKeyring extends EventEmitter {
   }
 
   _setupListener () {
-    const eventListener = ({ origin, data }) => {
+    this._eventListener = ({ origin, data }) => {
       if (origin !== this._getOrigin()) {
         return false
       }
@@ -501,7 +501,13 @@ class LedgerBridgeKeyring extends EventEmitter {
 
       return undefined
     }
-    window.addEventListener('message', eventListener)
+    window.addEventListener('message', this._eventListener)
+  }
+
+  destroy () {
+    window.removeEventListener('message', this._eventListener)
+    this.currentMessageId = 0
+    this.messageCallbacks = {}
   }
 
   async __getPage (increment) {

--- a/index.js
+++ b/index.js
@@ -506,8 +506,6 @@ class LedgerBridgeKeyring extends EventEmitter {
 
   destroy () {
     window.removeEventListener('message', this._eventListener)
-    this.currentMessageId = 0
-    this.messageCallbacks = {}
   }
 
   async __getPage (increment) {

--- a/test/test-eth-ledger-bridge-keyring.js
+++ b/test/test-eth-ledger-bridge-keyring.js
@@ -650,4 +650,14 @@ describe('LedgerBridgeKeyring', function () {
       assert.rejects(keyring.signTypedData(fakeAccounts[15], fixtureData, options), new Error('Ledger: The signature doesnt match the right address'))
     })
   })
+
+  describe('destroy', function () {
+    it('should remove the message event listener', function () {
+      sandbox.on(global.window, 'removeEventListener', () => true)
+      keyring.destroy()
+      expect(global.window.removeEventListener).to.have.been.called()
+      expect(global.window.removeEventListener)
+        .to.have.been.called.with('message', keyring._eventListener)
+    })
+  })
 })

--- a/test/window.shim.js
+++ b/test/window.shim.js
@@ -3,10 +3,16 @@ try {
     addEventListener: (_) => {
       return false
     },
+    removeEventListener: (_) => {
+      return false
+    },
   }
 } catch (e) {
   module.exports = {
     addEventListener: (_) => {
+      return false
+    },
+    removeEventListener: (_) => {
       return false
     },
   }


### PR DESCRIPTION
This message removes the 'message' listener and resets the `currentMessageId` and `messageCallbacks` properties