### PR TITLE
Incorrect V for EIP712 signature

### DIFF
--- a/index.js
+++ b/index.js
@@ -349,7 +349,7 @@ class LedgerBridgeKeyring extends EventEmitter {
           },
           ({ success, payload }) => {
             if (success) {
-              let v = payload.v - 27
+              let v = parseInt(payload.v, 10)
               v = v.toString(16)
               if (v.length < 2) {
                 v = `0${v}`

--- a/index.js
+++ b/index.js
@@ -414,7 +414,7 @@ class LedgerBridgeKeyring extends EventEmitter {
     })
 
     if (success) {
-      let v = payload.v - 27
+      let v = parseInt(payload.v, 10)
       v = v.toString(16)
       if (v.length < 2) {
         v = `0${v}`

--- a/test/test-eth-ledger-bridge-keyring.js
+++ b/test/test-eth-ledger-bridge-keyring.js
@@ -682,7 +682,7 @@ describe('LedgerBridgeKeyring', function () {
       })
 
       const result = await keyring.signTypedData(fakeAccounts[15], fixtureData, options)
-      assert.strictEqual(result, '0x72d4e38a0e582e09a620fd38e236fe687a1ec782206b56d576f579c026a7e5b946759735981cd0c3efb02d36df28bb2feedfec3d90e408efc93f45b894946e3200')
+      assert.strictEqual(result, '0x72d4e38a0e582e09a620fd38e236fe687a1ec782206b56d576f579c026a7e5b946759735981cd0c3efb02d36df28bb2feedfec3d90e408efc93f45b894946e321b')
     })
 
     it('should error when address does not match', async function () {


### PR DESCRIPTION
As described by #134 and #151, the V parsed by Metamask for a `signTypedData` is incorrect. The signature is not expected to be composed with the parity/recovery but with the classic `27` or `28`.

This PR fixes this and updates the CI tests.

Thanks 🙏 