### PR TITLE
feat: add mobile bridge

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -41,10 +41,10 @@ module.exports = {
   // An object that configures minimum threshold enforcement for coverage results
   coverageThreshold: {
     global: {
-      branches: 65.42,
-      functions: 88.57,
-      lines: 81.57,
-      statements: 81.49,
+      branches: 72.25,
+      functions: 90.62,
+      lines: 85.3,
+      statements: 85.2,
     },
   },
 

--- a/jest.config.js
+++ b/jest.config.js
@@ -41,10 +41,10 @@ module.exports = {
   // An object that configures minimum threshold enforcement for coverage results
   coverageThreshold: {
     global: {
-      branches: 65.42,
-      functions: 88.57,
-      lines: 81.63,
-      statements: 81.55,
+      branches: 72.67,
+      functions: 90.81,
+      lines: 84.98,
+      statements: 84.88,
     },
   },
 

--- a/jest.config.js
+++ b/jest.config.js
@@ -41,10 +41,10 @@ module.exports = {
   // An object that configures minimum threshold enforcement for coverage results
   coverageThreshold: {
     global: {
-      branches: 72.5,
-      functions: 91.08,
-      lines: 85.35,
-      statements: 85.25,
+      branches: 72.67,
+      functions: 90.81,
+      lines: 84.94,
+      statements: 84.84,
     },
   },
 

--- a/jest.config.js
+++ b/jest.config.js
@@ -43,8 +43,8 @@ module.exports = {
     global: {
       branches: 72.67,
       functions: 90.81,
-      lines: 84.98,
-      statements: 84.88,
+      lines: 84.84,
+      statements: 84.75,
     },
   },
 

--- a/jest.config.js
+++ b/jest.config.js
@@ -41,10 +41,10 @@ module.exports = {
   // An object that configures minimum threshold enforcement for coverage results
   coverageThreshold: {
     global: {
-      branches: 72.25,
-      functions: 90.62,
-      lines: 85.3,
-      statements: 85.2,
+      branches: 72.5,
+      functions: 91,
+      lines: 85.31,
+      statements: 85.21,
     },
   },
 

--- a/jest.config.js
+++ b/jest.config.js
@@ -42,9 +42,9 @@ module.exports = {
   coverageThreshold: {
     global: {
       branches: 72.5,
-      functions: 91,
-      lines: 85.31,
-      statements: 85.21,
+      functions: 91.08,
+      lines: 85.35,
+      statements: 85.25,
     },
   },
 

--- a/package.json
+++ b/package.json
@@ -37,10 +37,10 @@
     "test:watch": "jest --watch"
   },
   "dependencies": {
-    "@ledgerhq/hw-app-eth": "^6.32.0",
     "@ethereumjs/rlp": "^4.0.0",
     "@ethereumjs/tx": "^4.1.1",
     "@ethereumjs/util": "^8.0.0",
+    "@ledgerhq/hw-app-eth": "^6.32.0",
     "@metamask/utils": "^5.0.0",
     "eth-sig-util": "^2.0.0",
     "hdkey": "0.8.0"

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
   },
   "dependencies": {
     "@ethereumjs/tx": "^4.1.1",
+    "@ledgerhq/hw-app-eth": "^6.32.0",
     "@metamask/utils": "^5.0.0",
     "eth-sig-util": "^2.0.0",
     "ethereumjs-util": "^7.0.9",
@@ -46,7 +47,7 @@
   "devDependencies": {
     "@ethereumjs/common": "^3.1.1",
     "@lavamoat/allow-scripts": "^2.3.0",
-    "@ledgerhq/hw-app-eth": "^6.32.0",
+    "@ledgerhq/hw-transport": "^6.28.8",
     "@metamask/auto-changelog": "^3.1.0",
     "@metamask/eslint-config": "^11.0.1",
     "@metamask/eslint-config-browser": "^11.0.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
 export * from './ledger-keyring';
 export * from './ledger-iframe-bridge';
+export * from './ledger-mobile-bridge';
 export * from './ledger-bridge';

--- a/src/ledger-bridge.ts
+++ b/src/ledger-bridge.ts
@@ -32,9 +32,13 @@ export interface LedgerBridge<T extends Record<string, unknown>> {
 
   destroy(): Promise<void>;
 
-  getOptions(): T;
+  serializeData(): Promise<Record<string, unknown>>;
 
-  setOptions(opts: T): void;
+  deserializeData(opts: Record<string, unknown>): Promise<void>;
+
+  getOptions(): Promise<T>;
+
+  setOptions(opts: T): Promise<void>;
 
   attemptMakeApp(): Promise<boolean>;
 

--- a/src/ledger-bridge.ts
+++ b/src/ledger-bridge.ts
@@ -3,9 +3,7 @@ import type LedgerHwAppEth from '@ledgerhq/hw-app-eth';
 export type GetPublicKeyParams = { hdPath: string };
 export type GetPublicKeyResponse = Awaited<
   ReturnType<LedgerHwAppEth['getAddress']>
-> & {
-  chainCode: string;
-};
+>;
 
 export type LedgerSignTransactionParams = { hdPath: string; tx: string };
 export type LedgerSignTransactionResponse = Awaited<
@@ -26,15 +24,26 @@ export type LedgerSignTypedDataResponse = Awaited<
   ReturnType<LedgerHwAppEth['signEIP712HashedMessage']>
 >;
 
+export type ITransportMiddleware = {
+  dispose(): Promise<void>;
+};
+
 // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
 export interface LedgerBridge {
   isDeviceConnected: boolean;
+  transportMiddleware: ITransportMiddleware | unknown;
 
-  init(bridgeUrl: string): Promise<void>;
+  init(): Promise<void>;
 
   destroy(): Promise<void>;
 
+  getMetadata(): Promise<Record<string, string>>;
+
+  setMetadata(metadata?: Record<string, string>): Promise<void>;
+
   attemptMakeApp(): Promise<boolean>;
+
+  getTransportMiddleware(): Promise<unknown>;
 
   updateTransportMethod(transportType: string): Promise<boolean>;
 

--- a/src/ledger-bridge.ts
+++ b/src/ledger-bridge.ts
@@ -24,26 +24,19 @@ export type LedgerSignTypedDataResponse = Awaited<
   ReturnType<LedgerHwAppEth['signEIP712HashedMessage']>
 >;
 
-export type ITransportMiddleware = {
-  dispose(): Promise<void>;
-};
-
 // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
-export interface LedgerBridge {
+export interface LedgerBridge<T extends Record<string, unknown>> {
   isDeviceConnected: boolean;
-  transportMiddleware: ITransportMiddleware | unknown;
 
   init(): Promise<void>;
 
   destroy(): Promise<void>;
 
-  getMetadata(): Promise<Record<string, string>>;
+  getOptions(): T;
 
-  setMetadata(metadata?: Record<string, string>): Promise<void>;
+  setOptions(opts: T): void;
 
   attemptMakeApp(): Promise<boolean>;
-
-  getTransportMiddleware(): Promise<unknown>;
 
   updateTransportMethod(transportType: string): Promise<boolean>;
 

--- a/src/ledger-iframe-bridge.test.ts
+++ b/src/ledger-iframe-bridge.test.ts
@@ -75,7 +75,7 @@ describe('LedgerIframeBridge', function () {
 
   beforeEach(async function () {
     bridge = new LedgerIframeBridge();
-    await bridge.init('bridgeUrl');
+    await bridge.init();
     await simulateIFrameLoad(bridge.iframe);
   });
 
@@ -89,7 +89,7 @@ describe('LedgerIframeBridge', function () {
 
       const addEventListenerSpy = jest.spyOn(global.window, 'addEventListener');
 
-      await bridge.init('bridgeUrl');
+      await bridge.init();
 
       expect(addEventListenerSpy).toHaveBeenCalledTimes(1);
       expect(bridge.iframeLoaded).toBe(false);

--- a/src/ledger-iframe-bridge.ts
+++ b/src/ledger-iframe-bridge.ts
@@ -109,9 +109,7 @@ export class LedgerIframeBridge
   };
 
   constructor(opts?: LedgerIframeBridgeOptions) {
-    if (opts) {
-      this.setOptions(opts);
-    }
+    this.bridgeUrl = opts?.bridgeUrl ?? BRIDGE_URL;
   }
 
   async init() {
@@ -128,14 +126,26 @@ export class LedgerIframeBridge
     }
   }
 
-  getOptions(): LedgerIframeBridgeOptions {
+  async deserializeData(serializeData: Record<string, unknown>): Promise<void> {
+    this.bridgeUrl = (serializeData.bridgeUrl as string) ?? this.bridgeUrl;
+  }
+
+  async serializeData(): Promise<Record<string, unknown>> {
     return {
       bridgeUrl: this.bridgeUrl,
     };
   }
 
-  setOptions(opts: LedgerIframeBridgeOptions): void {
-    this.bridgeUrl = opts.bridgeUrl ?? BRIDGE_URL;
+  async getOptions(): Promise<LedgerIframeBridgeOptions> {
+    return { bridgeUrl: this.bridgeUrl };
+  }
+
+  async setOptions(opts: LedgerIframeBridgeOptions): Promise<void> {
+    if (opts.bridgeUrl && this.bridgeUrl !== opts.bridgeUrl) {
+      this.bridgeUrl = opts.bridgeUrl;
+      await this.destroy();
+      await this.init();
+    }
   }
 
   async attemptMakeApp(): Promise<boolean> {

--- a/src/ledger-iframe-bridge.ts
+++ b/src/ledger-iframe-bridge.ts
@@ -75,14 +75,18 @@ type IFramePostMessage<TAction extends IFrameMessageAction> =
 
 const BRIDGE_URL = 'https://metamask.github.io/eth-ledger-bridge-keyring';
 
-export class LedgerIframeBridge implements LedgerBridge {
-  iframe?: HTMLIFrameElement;
+export type LedgerIframeBridgeOptions = {
+  bridgeUrl: string;
+};
 
-  transportMiddleware: unknown;
+export class LedgerIframeBridge
+  implements LedgerBridge<LedgerIframeBridgeOptions>
+{
+  iframe?: HTMLIFrameElement;
 
   iframeLoaded = false;
 
-  bridgeUrl = BRIDGE_URL;
+  bridgeUrl = '';
 
   eventListener?: (eventMessage: {
     origin: string;
@@ -104,6 +108,12 @@ export class LedgerIframeBridge implements LedgerBridge {
     transportType: string;
   };
 
+  constructor(opts?: LedgerIframeBridgeOptions) {
+    if (opts) {
+      this.setOptions(opts);
+    }
+  }
+
   async init() {
     this.#setupIframe(this.bridgeUrl);
 
@@ -118,16 +128,14 @@ export class LedgerIframeBridge implements LedgerBridge {
     }
   }
 
-  async getMetadata(): Promise<Record<string, string>> {
-    return Promise.resolve({
+  getOptions(): LedgerIframeBridgeOptions {
+    return {
       bridgeUrl: this.bridgeUrl,
-    });
+    };
   }
 
-  async setMetadata(metadata?: Record<string, string>): Promise<void> {
-    if (metadata) {
-      this.bridgeUrl = metadata.bridgeUrl ?? BRIDGE_URL;
-    }
+  setOptions(opts: LedgerIframeBridgeOptions): void {
+    this.bridgeUrl = opts.bridgeUrl ?? BRIDGE_URL;
   }
 
   async attemptMakeApp(): Promise<boolean> {
@@ -173,10 +181,6 @@ export class LedgerIframeBridge implements LedgerBridge {
         },
       );
     });
-  }
-
-  async getTransportMiddleware(): Promise<unknown> {
-    return this.transportMiddleware;
   }
 
   async getPublicKey(

--- a/src/ledger-keyring.test.ts
+++ b/src/ledger-keyring.test.ts
@@ -152,7 +152,7 @@ describe('LedgerKeyring', function () {
     it('serializes an instance', async function () {
       const output = await keyring.serialize();
 
-      expect(output.bridgeUrl).toBe(
+      expect(output.metadata.bridgeUrl).toBe(
         'https://metamask.github.io/eth-ledger-bridge-keyring',
       );
       expect(output.hdPath).toBe(`m/44'/60'/0'`);
@@ -179,7 +179,7 @@ describe('LedgerKeyring', function () {
       const serialized = await keyring.serialize();
 
       expect(serialized.accounts).toHaveLength(1);
-      expect(serialized.bridgeUrl).toBe(
+      expect(serialized.metadata.bridgeUrl).toBe(
         'https://metamask.github.io/eth-ledger-bridge-keyring',
       );
       expect(serialized.hdPath).toBe(someHdPath);
@@ -448,14 +448,6 @@ describe('LedgerKeyring', function () {
     it('returns the expected', function () {
       const expectedAccount = fakeAccounts[accountIndex];
       expect(accounts[0]).toStrictEqual(expectedAccount);
-    });
-  });
-
-  describe('exportAccount', function () {
-    it('should throw an error because it is not supported', function () {
-      expect(() => {
-        keyring.exportAccount();
-      }).toThrow('Not supported on this device');
     });
   });
 

--- a/src/ledger-keyring.test.ts
+++ b/src/ledger-keyring.test.ts
@@ -6,7 +6,10 @@ import * as ethUtil from 'ethereumjs-util';
 import HDKey from 'hdkey';
 
 import { LedgerBridge } from './ledger-bridge';
-import { LedgerIframeBridge } from './ledger-iframe-bridge';
+import {
+  LedgerIframeBridge,
+  LedgerIframeBridgeOptions,
+} from './ledger-iframe-bridge';
 import { AccountDetails, LedgerKeyring } from './ledger-keyring';
 
 const fakeAccounts = [
@@ -76,8 +79,8 @@ const fakeTypeTwoTx = TransactionFactory.fromTxData(
 
 describe('LedgerKeyring', function () {
   let keyring: LedgerKeyring;
-  let bridge: LedgerBridge;
-
+  let bridge: LedgerBridge<Record<string, unknown>>;
+  const opts = { bridgeUrl: 'bridgeUrl' };
   /**
    * Sets up the keyring to unlock one account.
    *
@@ -93,7 +96,7 @@ describe('LedgerKeyring', function () {
   }
 
   beforeEach(async function () {
-    bridge = new LedgerIframeBridge();
+    bridge = new LedgerIframeBridge(opts);
     keyring = new LedgerKeyring({ bridge });
     keyring.hdk = fakeHdKey;
     await keyring.deserialize();
@@ -119,7 +122,7 @@ describe('LedgerKeyring', function () {
   describe('constructor', function () {
     it('constructs', async function () {
       const ledgerKeyring = new LedgerKeyring({
-        bridge: new LedgerIframeBridge(),
+        bridge: new LedgerIframeBridge(opts),
       });
       expect(typeof ledgerKeyring).toBe('object');
 
@@ -131,7 +134,8 @@ describe('LedgerKeyring', function () {
       expect(
         () =>
           new LedgerKeyring({
-            bridge: undefined as unknown as LedgerBridge,
+            bridge:
+              undefined as unknown as LedgerBridge<LedgerIframeBridgeOptions>,
           }),
       ).toThrow('Bridge is a required dependency for the keyring');
     });
@@ -152,7 +156,7 @@ describe('LedgerKeyring', function () {
     it('serializes an instance', async function () {
       const output = await keyring.serialize();
 
-      expect(output.metadata.bridgeUrl).toBe(
+      expect(output.bridgeOptions.bridgeUrl).toBe(
         'https://metamask.github.io/eth-ledger-bridge-keyring',
       );
       expect(output.hdPath).toBe(`m/44'/60'/0'`);
@@ -179,7 +183,7 @@ describe('LedgerKeyring', function () {
       const serialized = await keyring.serialize();
 
       expect(serialized.accounts).toHaveLength(1);
-      expect(serialized.metadata.bridgeUrl).toBe(
+      expect(serialized.bridgeOptions.bridgeUrl).toBe(
         'https://metamask.github.io/eth-ledger-bridge-keyring',
       );
       expect(serialized.hdPath).toBe(someHdPath);

--- a/src/ledger-keyring.test.ts
+++ b/src/ledger-keyring.test.ts
@@ -10,10 +10,7 @@ import {
   LedgerIframeBridge,
   LedgerIframeBridgeOptions,
 } from './ledger-iframe-bridge';
-import {
-  AccountDetails,
-  LedgerKeyring,
-} from './ledger-keyring';
+import { AccountDetails, LedgerKeyring } from './ledger-keyring';
 
 const fakeAccounts = [
   '0xF30952A1c534CDE7bC471380065726fa8686dfB3',
@@ -80,7 +77,7 @@ const fakeTypeTwoTx = TransactionFactory.fromTxData(
   { common: commonEIP1559, freeze: false },
 );
 
-const BRIDGE_URL = 'BRIDGE_URL'
+const BRIDGE_URL = 'BRIDGE_URL';
 
 describe('LedgerKeyring', function () {
   let keyring: LedgerKeyring;
@@ -161,9 +158,7 @@ describe('LedgerKeyring', function () {
     it('serializes an instance', async function () {
       const output = await keyring.serialize();
 
-      expect(output.bridgeOptions.bridgeUrl).toBe(
-        BRIDGE_URL,
-      );
+      expect(output.bridgeOptions.bridgeUrl).toStrictEqual(BRIDGE_URL);
       expect(output.hdPath).toBe(`m/44'/60'/0'`);
       expect(Array.isArray(output.accounts)).toBe(true);
       expect(output.accounts).toHaveLength(0);
@@ -188,9 +183,7 @@ describe('LedgerKeyring', function () {
       const serialized = await keyring.serialize();
 
       expect(serialized.accounts).toHaveLength(1);
-      expect(serialized.bridgeOptions.bridgeUrl).toBe(
-        BRIDGE_URL,
-      );
+      expect(serialized.bridgeOptions.bridgeUrl).toBe(BRIDGE_URL);
       expect(serialized.hdPath).toBe(someHdPath);
       expect(serialized.accountDetails).toStrictEqual(accountDetails);
     });

--- a/src/ledger-keyring.test.ts
+++ b/src/ledger-keyring.test.ts
@@ -10,7 +10,10 @@ import {
   LedgerIframeBridge,
   LedgerIframeBridgeOptions,
 } from './ledger-iframe-bridge';
-import { AccountDetails, LedgerKeyring } from './ledger-keyring';
+import {
+  AccountDetails,
+  LedgerKeyring,
+} from './ledger-keyring';
 
 const fakeAccounts = [
   '0xF30952A1c534CDE7bC471380065726fa8686dfB3',
@@ -77,10 +80,12 @@ const fakeTypeTwoTx = TransactionFactory.fromTxData(
   { common: commonEIP1559, freeze: false },
 );
 
+const BRIDGE_URL = 'BRIDGE_URL'
+
 describe('LedgerKeyring', function () {
   let keyring: LedgerKeyring;
   let bridge: LedgerBridge<Record<string, unknown>>;
-  const opts = { bridgeUrl: 'bridgeUrl' };
+  const opts = { bridgeUrl: BRIDGE_URL };
   /**
    * Sets up the keyring to unlock one account.
    *
@@ -157,7 +162,7 @@ describe('LedgerKeyring', function () {
       const output = await keyring.serialize();
 
       expect(output.bridgeOptions.bridgeUrl).toBe(
-        'https://metamask.github.io/eth-ledger-bridge-keyring',
+        BRIDGE_URL,
       );
       expect(output.hdPath).toBe(`m/44'/60'/0'`);
       expect(Array.isArray(output.accounts)).toBe(true);
@@ -184,7 +189,7 @@ describe('LedgerKeyring', function () {
 
       expect(serialized.accounts).toHaveLength(1);
       expect(serialized.bridgeOptions.bridgeUrl).toBe(
-        'https://metamask.github.io/eth-ledger-bridge-keyring',
+        BRIDGE_URL,
       );
       expect(serialized.hdPath).toBe(someHdPath);
       expect(serialized.accountDetails).toStrictEqual(accountDetails);

--- a/src/ledger-keyring.ts
+++ b/src/ledger-keyring.ts
@@ -1,5 +1,4 @@
 import { TransactionFactory, TxData, TypedTransaction } from '@ethereumjs/tx';
-import type Transport from '@ledgerhq/hw-transport';
 // eslint-disable-next-line import/no-nodejs-modules
 import { Buffer } from 'buffer';
 import * as sigUtil from 'eth-sig-util';

--- a/src/ledger-keyring.ts
+++ b/src/ledger-keyring.ts
@@ -112,7 +112,7 @@ export class LedgerKeyring extends EventEmitter {
       accounts: this.accounts,
       accountDetails: this.accountDetails,
       implementFullBIP44: false,
-      bridgeOptions: this.bridge.getOptions(),
+      bridgeOptions: await this.bridge.serializeData(),
     };
   }
 
@@ -121,7 +121,7 @@ export class LedgerKeyring extends EventEmitter {
     this.accounts = opts.accounts ?? [];
     this.accountDetails = opts.accountDetails ?? {};
 
-    this.bridge.setOptions(opts.bridgeOptions ?? {});
+    await this.bridge.deserializeData(opts.bridgeOptions ?? {});
 
     if (!opts.accountDetails) {
       this.#migrateAccountDetails(opts);

--- a/src/ledger-keyring.ts
+++ b/src/ledger-keyring.ts
@@ -24,7 +24,7 @@ enum NetworkApiUrls {
 }
 
 type SignTransactionPayload = Awaited<
-  ReturnType<LedgerBridge['deviceSignTransaction']>
+  ReturnType<LedgerBridge<Record<string, unknown>>['deviceSignTransaction']>
 >;
 
 export type AccountDetails = {
@@ -39,7 +39,7 @@ export type LedgerBridgeKeyringOptions = {
   accountDetails: Readonly<Record<string, AccountDetails>>;
   accountIndexes: Readonly<Record<string, number>>;
   implementFullBIP44: boolean;
-  metadata: Record<string, string>;
+  bridgeOptions: Record<string, unknown>;
 };
 
 /**
@@ -86,9 +86,9 @@ export class LedgerKeyring extends EventEmitter {
 
   implementFullBIP44 = false;
 
-  bridge: LedgerBridge;
+  bridge: LedgerBridge<Record<string, unknown>>;
 
-  constructor({ bridge }: { bridge: LedgerBridge }) {
+  constructor({ bridge }: { bridge: LedgerBridge<Record<string, unknown>> }) {
     super();
 
     if (!bridge) {
@@ -112,7 +112,7 @@ export class LedgerKeyring extends EventEmitter {
       accounts: this.accounts,
       accountDetails: this.accountDetails,
       implementFullBIP44: false,
-      metadata: await this.bridge.getMetadata(),
+      bridgeOptions: this.bridge.getOptions(),
     };
   }
 
@@ -121,7 +121,7 @@ export class LedgerKeyring extends EventEmitter {
     this.accounts = opts.accounts ?? [];
     this.accountDetails = opts.accountDetails ?? {};
 
-    await this.bridge.setMetadata(opts.metadata);
+    this.bridge.setOptions(opts.bridgeOptions ?? {});
 
     if (!opts.accountDetails) {
       this.#migrateAccountDetails(opts);

--- a/src/ledger-mobile-bridge.test.ts
+++ b/src/ledger-mobile-bridge.test.ts
@@ -111,7 +111,7 @@ describe('LedgerMobileBridge', function () {
       bridge.setDeviceId(DEVICE_ID);
       await bridge.forgetDevice();
       expect(bridge.isDeviceConnected).toBe(false);
-      expect(bridge.deviceId).toBe('');
+      expect(bridge.getDeviceId()).toBe('');
     });
   });
 
@@ -199,9 +199,9 @@ describe('LedgerMobileBridge', function () {
 
   describe('deserializeData', function () {
     it('data has assigned to instance', async function () {
-      bridge.deviceId = '';
+      bridge.setDeviceId('');
       await bridge.deserializeData({ deviceId: DEVICE_ID });
-      expect(bridge.deviceId).toBe(DEVICE_ID);
+      expect(bridge.getDeviceId()).toBe(DEVICE_ID);
     });
   });
 
@@ -222,7 +222,7 @@ describe('LedgerMobileBridge', function () {
       expect(transportMiddlewareSetTransportSpy).toHaveBeenCalledWith(
         mockTransport,
       );
-      expect(bridge.deviceId).toBe(DEVICE_ID);
+      expect(bridge.getDeviceId()).toBe(DEVICE_ID);
       expect(bridge.isDeviceConnected).toBe(true);
       mockTransport.deviceModel.id = '';
     });
@@ -267,13 +267,12 @@ describe('LedgerMobileBridge', function () {
 
   describe('setOption', function () {
     it('option set correctly', async function () {
-      bridge.deviceId = '';
+      bridge.setDeviceId('');
       await bridge.setOptions({ deviceId: DEVICE_ID });
-      expect(bridge.deviceId).toBe(DEVICE_ID);
+      expect(bridge.getDeviceId()).toBe(DEVICE_ID);
     });
 
     it('throw error when device id has set but different device id given', async function () {
-      bridge.deviceId = '';
       await bridge.setOptions({ deviceId: DEVICE_ID });
       await expect(
         bridge.setOptions({ deviceId: 'another id' }),

--- a/src/ledger-mobile-bridge.test.ts
+++ b/src/ledger-mobile-bridge.test.ts
@@ -1,0 +1,353 @@
+import ledgerService from '@ledgerhq/hw-app-eth/lib/services/ledger';
+
+import {
+  LedgerMobileBridge,
+  LedgerTransportMiddleware,
+} from './ledger-mobile-bridge';
+
+const DEVICE_ID = 'DEVICE_ID';
+
+describe('LedgerMobileBridge', function () {
+  let bridge: LedgerMobileBridge;
+  let transportMiddleware: LedgerTransportMiddleware;
+  let transportMiddlewareDisposeSpy: jest.SpyInstance;
+  let transportMiddlewareGetEthAppSpy: jest.SpyInstance;
+  const mockEthApp = {
+    signEIP712HashedMessage: jest.fn(),
+    signTransaction: jest.fn(),
+    getAddress: jest.fn(),
+    signPersonalMessage: jest.fn(),
+  };
+
+  beforeEach(async function () {
+    transportMiddleware = new LedgerTransportMiddleware();
+    transportMiddlewareDisposeSpy = jest
+      .spyOn(transportMiddleware, 'dispose')
+      .mockImplementation(async () => Promise.resolve());
+    transportMiddlewareGetEthAppSpy = jest
+      .spyOn(transportMiddleware, 'getEthApp')
+      .mockImplementation(async () => Promise.resolve(mockEthApp as any));
+    bridge = new LedgerMobileBridge(transportMiddleware);
+  });
+
+  afterEach(function () {
+    jest.clearAllMocks();
+  });
+
+  describe('getTransportMiddleWare', function () {
+    it('return tansportMiddleware', async function () {
+      const result = bridge.getTransportMiddleWare();
+      expect(result).toStrictEqual(transportMiddleware);
+    });
+
+    it('throw error if tansportMiddleware not set', async function () {
+      bridge = new LedgerMobileBridge(
+        undefined as unknown as LedgerTransportMiddleware,
+      );
+      expect(() => bridge.getTransportMiddleWare()).toThrow(
+        'transportMiddleware is not initialized.',
+      );
+    });
+  });
+
+  describe('destroy', function () {
+    it('trigger middleware dispose', async function () {
+      await bridge.destroy();
+      expect(transportMiddlewareDisposeSpy).toHaveBeenCalledTimes(1);
+      expect(bridge.isDeviceConnected).toBe(false);
+    });
+  });
+
+  describe('attemptMakeApp', function () {
+    it('throw error not supported', async function () {
+      await expect(bridge.attemptMakeApp()).rejects.toThrow(
+        'Method not supported.',
+      );
+    });
+  });
+
+  describe('updateTransportMethod', function () {
+    it('throw error not supported', async function () {
+      await expect(bridge.updateTransportMethod()).rejects.toThrow(
+        'Method not supported.',
+      );
+    });
+  });
+
+  describe('forgetDevice', function () {
+    it('clean up', async function () {
+      bridge.setDeviceId(DEVICE_ID);
+      await bridge.forgetDevice();
+      expect(bridge.isDeviceConnected).toBe(false);
+      expect(bridge.deviceId).toBe('');
+    });
+  });
+
+  describe('deviceSignMessage', function () {
+    it('sends and processes a successful ledger-sign-personal-message message', async function () {
+      const hdPath = "m/44'/60'/0'/0/0";
+      const message = 'message';
+      await bridge.deviceSignMessage({
+        hdPath,
+        message,
+      });
+      expect(transportMiddlewareGetEthAppSpy).toHaveBeenCalledTimes(1);
+      expect(mockEthApp.signPersonalMessage).toHaveBeenCalledTimes(1);
+      expect(mockEthApp.signPersonalMessage).toHaveBeenCalledWith(
+        hdPath,
+        message,
+      );
+    });
+  });
+
+  describe('getPublicKey', function () {
+    it('sends and processes a successful ledger-unlock message', async function () {
+      const hdPath = "m/44'/60'/0'/0/0";
+      await bridge.getPublicKey({
+        hdPath,
+      });
+      expect(transportMiddlewareGetEthAppSpy).toHaveBeenCalledTimes(1);
+      expect(mockEthApp.getAddress).toHaveBeenCalledTimes(1);
+      expect(mockEthApp.getAddress).toHaveBeenCalledWith(hdPath, false, true);
+    });
+  });
+
+  describe('deviceSignTransaction', function () {
+    it('sends and processes a successful ledger-sign-transaction message', async function () {
+      const hdPath = "m/44'/60'/0'/0/0";
+      const tx =
+        'f86d8202b38477359400825208944592d8f8d7b001e72cb26a73e4fa1806a51ac79d880de0b6b3a7640000802ba0699ff162205967ccbabae13e07cdd4284258d46ec1051a70a51be51ec2bc69f3a04e6944d508244ea54a62ebf9a72683eeadacb73ad7c373ee542f1998147b220e';
+      const resolution = await ledgerService.resolveTransaction(tx, {}, {});
+      await bridge.deviceSignTransaction({
+        hdPath,
+        tx,
+      });
+      expect(transportMiddlewareGetEthAppSpy).toHaveBeenCalledTimes(1);
+      expect(mockEthApp.signTransaction).toHaveBeenCalledTimes(1);
+      expect(mockEthApp.signTransaction).toHaveBeenCalledWith(
+        hdPath,
+        tx,
+        resolution,
+      );
+    });
+
+    it('throws an error when tx format is not correct', async function () {
+      const hdPath = "m/44'/60'/0'/0/0";
+      const tx = '';
+      await expect(
+        bridge.deviceSignTransaction({
+          hdPath,
+          tx,
+        }),
+      ).rejects.toThrow(Error);
+      expect(transportMiddlewareGetEthAppSpy).toHaveBeenCalledTimes(0);
+      expect(mockEthApp.signTransaction).toHaveBeenCalledTimes(0);
+    });
+  });
+
+  describe('deviceSignTypedData', function () {
+    it('sends and processes a successful ledger-sign-typed-data message', async function () {
+      const hdPath = "m/44'/60'/0'/0/0";
+      const domainSeparatorHex = 'domainSeparatorHex';
+      const hashStructMessageHex = 'hashStructMessageHex';
+      await bridge.deviceSignTypedData({
+        hdPath,
+        domainSeparatorHex,
+        hashStructMessageHex,
+      });
+      expect(transportMiddlewareGetEthAppSpy).toHaveBeenCalledTimes(1);
+      expect(mockEthApp.signEIP712HashedMessage).toHaveBeenCalledTimes(1);
+      expect(mockEthApp.signEIP712HashedMessage).toHaveBeenCalledWith(
+        hdPath,
+        domainSeparatorHex,
+        hashStructMessageHex,
+      );
+    });
+  });
+
+  describe('deserializeData', function () {
+    it('data has assigned to instance', async function () {
+      bridge.deviceId = '';
+      await bridge.deserializeData({ deviceId: DEVICE_ID });
+      expect(bridge.deviceId).toBe(DEVICE_ID);
+    });
+  });
+
+  describe('serializeData', function () {
+    it('return struct data', async function () {
+      await bridge.deserializeData({ deviceId: DEVICE_ID });
+      const result = await bridge.serializeData();
+      expect(result).toStrictEqual({
+        deviceId: DEVICE_ID,
+      });
+    });
+  });
+
+  describe('setOption', function () {
+    it('option set correctly', async function () {
+      bridge.deviceId = '';
+      await bridge.setOptions({ deviceId: DEVICE_ID });
+      expect(bridge.deviceId).toBe(DEVICE_ID);
+      expect(bridge.isDeviceConnected).toBe(true);
+    });
+
+    it('throw error when device id has set but different device id given', async function () {
+      bridge.deviceId = '';
+      await bridge.setOptions({ deviceId: DEVICE_ID });
+      await expect(
+        bridge.setOptions({ deviceId: 'another id' }),
+      ).rejects.toThrow('deviceId mismatch.');
+    });
+  });
+
+  describe('getOption', function () {
+    it('return instance options', async function () {
+      await bridge.setOptions({ deviceId: DEVICE_ID });
+      const result = await bridge.getOptions();
+      expect(result).toStrictEqual({
+        deviceId: DEVICE_ID,
+      });
+    });
+  });
+});
+
+describe('LedgerTransportMiddleware', function () {
+  let transportMiddleware: LedgerTransportMiddleware;
+  const mockTransport = {
+    send: jest.fn(),
+    close: jest.fn(),
+    decorateAppAPIMethods: jest.fn(),
+  };
+
+  beforeEach(async function () {
+    transportMiddleware = new LedgerTransportMiddleware();
+    await transportMiddleware.setTransport(mockTransport as any);
+  });
+
+  afterEach(function () {
+    jest.clearAllMocks();
+  });
+
+  describe('dispose', function () {
+    it('transport should close', async function () {
+      await transportMiddleware.dispose();
+      expect(mockTransport.close).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('setTransport', function () {
+    it('transport should set', async function () {
+      transportMiddleware = new LedgerTransportMiddleware();
+      await expect(transportMiddleware.getTransport()).rejects.toThrow(Error);
+      await transportMiddleware.setTransport(mockTransport as any);
+      expect(transportMiddleware.getTransport()).toBeDefined();
+    });
+  });
+
+  describe('getTransport', function () {
+    it('return transport', async function () {
+      const transport = await transportMiddleware.getTransport();
+      expect(transport).toBe(mockTransport);
+    });
+
+    it('throw error when transport not set', async function () {
+      transportMiddleware = new LedgerTransportMiddleware();
+      await expect(transportMiddleware.getTransport()).rejects.toThrow(
+        'Ledger transport is not initialized. You must call setTransport first.',
+      );
+    });
+  });
+
+  describe('getEthApp', function () {
+    it('return eth app', async function () {
+      transportMiddleware = new LedgerTransportMiddleware();
+      await transportMiddleware.setTransport(mockTransport as any);
+      await transportMiddleware.initEthApp();
+      const app = await transportMiddleware.getEthApp();
+      expect(app).toBeDefined();
+    });
+
+    it('throw error when app not set', async function () {
+      await expect(transportMiddleware.getEthApp()).rejects.toThrow(
+        'Ledger app is not initialized. You must call setTransport first.',
+      );
+    });
+  });
+
+  describe('initEthApp', function () {
+    it('eth app should set', async function () {
+      await expect(transportMiddleware.getEthApp()).rejects.toThrow(Error);
+      await transportMiddleware.initEthApp();
+      expect(transportMiddleware.getEthApp()).toBeDefined();
+    });
+
+    it('throw error when transport not set', async function () {
+      transportMiddleware = new LedgerTransportMiddleware();
+      await expect(transportMiddleware.initEthApp()).rejects.toThrow(
+        'Ledger transport is not initialized. You must call setTransport first.',
+      );
+    });
+  });
+
+  describe('openEthApp', function () {
+    it('transport command should send correctly', async function () {
+      await transportMiddleware.openEthApp();
+      expect(mockTransport.send).toHaveBeenCalledTimes(1);
+      expect(mockTransport.send).toHaveBeenCalledWith(
+        0xe0,
+        0xd8,
+        0x00,
+        0x00,
+        Buffer.from(
+          transportMiddleware.ethAppName,
+          transportMiddleware.transportEncoding,
+        ),
+      );
+    });
+  });
+
+  describe('closeApps', function () {
+    it('transport command should send correctly', async function () {
+      await transportMiddleware.closeApps();
+      expect(mockTransport.send).toHaveBeenCalledTimes(1);
+      expect(mockTransport.send).toHaveBeenCalledWith(0xb0, 0xa7, 0x00, 0x00);
+    });
+  });
+
+  describe('getEthAppNameAndVersion', function () {
+    it('transport command should send correctly', async function () {
+      const appNameBuf = Buffer.alloc(7, 'appName', 'ascii');
+      const verionBuf = Buffer.alloc(6, 'verion', 'ascii');
+      const buffer = Buffer.alloc(20);
+      buffer[0] = 1;
+      buffer[1] = appNameBuf.length;
+      let j = 2;
+      for (let i = 0; i < appNameBuf.length; i++, j++) {
+        buffer[j] = appNameBuf[i] ?? 0;
+      }
+      buffer[j] = verionBuf.length;
+      j += 1;
+      for (let i = 0; i < verionBuf.length; i++, j++) {
+        buffer[j] = verionBuf[i] ?? 0;
+      }
+
+      jest.spyOn(mockTransport, 'send').mockReturnValueOnce(buffer);
+      const result = await transportMiddleware.getEthAppNameAndVersion();
+
+      expect(mockTransport.send).toHaveBeenCalledTimes(1);
+      expect(mockTransport.send).toHaveBeenCalledWith(0xb0, 0x01, 0x00, 0x00);
+      expect(result).toStrictEqual({
+        appName: 'appName',
+        version: 'verion',
+      });
+    });
+
+    it('throw error when buffer incorrect', async function () {
+      const buffer = Buffer.alloc(1);
+      jest.spyOn(mockTransport, 'send').mockReturnValueOnce(buffer);
+      await expect(
+        transportMiddleware.getEthAppNameAndVersion(),
+      ).rejects.toThrow('getEthAppNameAndVersion: format not supported');
+    });
+  });
+});

--- a/src/ledger-mobile-bridge.ts
+++ b/src/ledger-mobile-bridge.ts
@@ -1,0 +1,236 @@
+import LedgerHwAppEth from '@ledgerhq/hw-app-eth';
+import ledgerService from '@ledgerhq/hw-app-eth/lib/services/ledger';
+import type Transport from '@ledgerhq/hw-transport';
+// eslint-disable-next-line import/no-nodejs-modules
+import { Buffer } from 'buffer';
+
+import {
+  GetPublicKeyParams,
+  GetPublicKeyResponse,
+  LedgerBridge,
+  LedgerSignMessageParams,
+  LedgerSignMessageResponse,
+  LedgerSignTransactionParams,
+  LedgerSignTransactionResponse,
+  LedgerSignTypedDataParams,
+  LedgerSignTypedDataResponse,
+  ITransportMiddleware,
+} from './ledger-bridge';
+
+type GetEthAppNameAndVersionResponse = { appName: string; version: string };
+
+export type ILedgerMobileBridge = {
+  setDeviceId(deviceId: string): void;
+  getDeviceId(): string;
+};
+
+export type ILedgerMobileTransportMiddleware = {
+  getEthAppNameAndVersion(): Promise<GetEthAppNameAndVersionResponse>;
+  openEthApp(): Promise<void>;
+  closeApps(): Promise<void>;
+  setTransport(transport: Transport): Promise<boolean>;
+  getTransport(): Promise<Transport>;
+  getEthApp(): Promise<LedgerHwAppEth>;
+  initEthApp(): Promise<void>;
+} & ITransportMiddleware;
+
+/**
+ * LedgerMobileTransportMiddleware is a middleware to communicate with the Ledger device via transport or LedgerHwAppEth
+ */
+export class LedgerMobileTransportMiddleware
+  implements ILedgerMobileTransportMiddleware
+{
+  readonly mainAppName = 'BOLOS';
+
+  readonly ethAppName = 'Ethereum';
+
+  readonly transportEncoding = 'ascii';
+
+  app?: LedgerHwAppEth;
+
+  transport?: Transport;
+
+  async dispose(): Promise<void> {
+    const transport = await this.getTransport();
+    await transport.close();
+  }
+
+  async setTransport(transport: Transport): Promise<boolean> {
+    this.transport = transport;
+    return Promise.resolve(true);
+  }
+
+  async getTransport(): Promise<Transport> {
+    if (!this.transport) {
+      throw new Error(
+        'Ledger transport is not initialized. You must call setTransport first.',
+      );
+    }
+    return Promise.resolve(this.transport);
+  }
+
+  async getEthApp(): Promise<LedgerHwAppEth> {
+    if (!this.app) {
+      throw new Error(
+        'Ledger app is not initialized. You must call setTransport first.',
+      );
+    }
+    return Promise.resolve(this.app);
+  }
+
+  async initEthApp(): Promise<void> {
+    this.app = new LedgerHwAppEth(await this.getTransport());
+  }
+
+  async openEthApp(): Promise<void> {
+    const transport = await this.getTransport();
+    await transport.send(
+      0xe0,
+      0xd8,
+      0x00,
+      0x00,
+      Buffer.from(this.ethAppName, this.transportEncoding),
+    );
+  }
+
+  async closeApps(): Promise<void> {
+    const transport = await this.getTransport();
+    await transport.send(0xb0, 0xa7, 0x00, 0x00);
+  }
+
+  async getEthAppNameAndVersion(): Promise<GetEthAppNameAndVersionResponse> {
+    const transport = await this.getTransport();
+
+    const response = await transport.send(0xb0, 0x01, 0x00, 0x00);
+
+    let i = 1;
+    const format = response[i];
+
+    if (format !== 1) {
+      throw new Error('getEthAppNameAndVersion: format not supported');
+    }
+
+    i += 1;
+    const nameLength = response[i] ?? 0;
+    const appName = response
+      .slice(i, (i += nameLength))
+      .toString(this.transportEncoding);
+
+    i += 1;
+    const versionLength = response[i] ?? 0;
+    const version = response
+      .slice(i, (i += versionLength))
+      .toString(this.transportEncoding);
+
+    return {
+      appName,
+      version,
+    };
+  }
+}
+
+/**
+ * LedgerMobileBridge is a bridge between the LedgerKeyring and the LedgerMobileTransportMiddleware.
+ */
+export default class LedgerMobileBridge
+  implements LedgerBridge, ILedgerMobileBridge
+{
+  transportMiddleware: ILedgerMobileTransportMiddleware;
+
+  deviceId = '';
+
+  isDeviceConnected = false;
+
+  constructor() {
+    this.transportMiddleware = new LedgerMobileTransportMiddleware();
+  }
+
+  // init will be called by the eth keyring controller when new account added
+  async init(): Promise<void> {
+    return Promise.resolve();
+  }
+
+  setDeviceId(deviceId: string): void {
+    if (this.deviceId && this.deviceId !== deviceId) {
+      throw new Error('LedgerKeyring: deviceId mismatch.');
+    }
+    this.deviceId = deviceId;
+    this.isDeviceConnected = true;
+  }
+
+  getDeviceId(): string {
+    return this.deviceId;
+  }
+
+  async getTransportMiddleware(): Promise<ILedgerMobileTransportMiddleware> {
+    return this.transportMiddleware;
+  }
+
+  async updateTransportMethod(): Promise<boolean> {
+    throw new Error('Method not supported.');
+  }
+
+  async attemptMakeApp(): Promise<boolean> {
+    await this.transportMiddleware.initEthApp();
+    return true;
+  }
+
+  async destroy(): Promise<void> {
+    await this.transportMiddleware.dispose();
+    this.isDeviceConnected = false;
+  }
+
+  async forgetDevice(): Promise<void> {
+    this.deviceId = '';
+    this.isDeviceConnected = false;
+  }
+
+  async getMetadata(): Promise<Record<string, string>> {
+    return Promise.resolve({
+      deviceId: this.deviceId,
+    });
+  }
+
+  async setMetadata(metadata?: Record<string, string>): Promise<void> {
+    if (metadata) {
+      this.deviceId = metadata.deviceId ?? '';
+    }
+  }
+
+  async deviceSignMessage({
+    hdPath,
+    message,
+  }: LedgerSignMessageParams): Promise<LedgerSignMessageResponse> {
+    const app = await this.transportMiddleware.getEthApp();
+    return app.signPersonalMessage(hdPath, message);
+  }
+
+  async deviceSignTypedData({
+    hdPath,
+    domainSeparatorHex,
+    hashStructMessageHex,
+  }: LedgerSignTypedDataParams): Promise<LedgerSignTypedDataResponse> {
+    const app = await this.transportMiddleware.getEthApp();
+    return app.signEIP712HashedMessage(
+      hdPath,
+      domainSeparatorHex,
+      hashStructMessageHex,
+    );
+  }
+
+  async deviceSignTransaction({
+    tx,
+    hdPath,
+  }: LedgerSignTransactionParams): Promise<LedgerSignTransactionResponse> {
+    const resolution = await ledgerService.resolveTransaction(tx, {}, {});
+    const app = await this.transportMiddleware.getEthApp();
+    return app.signTransaction(hdPath, tx, resolution);
+  }
+
+  async getPublicKey({
+    hdPath,
+  }: GetPublicKeyParams): Promise<GetPublicKeyResponse> {
+    const app = await this.transportMiddleware.getEthApp();
+    return app.getAddress(hdPath, false, true);
+  }
+}

--- a/src/ledger-mobile-bridge.ts
+++ b/src/ledger-mobile-bridge.ts
@@ -32,6 +32,7 @@ export interface LedgerTransportMiddleware {
 export interface LedgerMobileBridge
   extends LedgerBridge<LedgerMobileBridgeOptions> {
   setDeviceId(deviceId: string): void;
+  getDeviceId(): string;
   getTransportMiddleWare(): LedgerTransportMiddleware;
   connect(transport: Transport, deviceId: string): Promise<void>;
   getEthAppNameAndVersion(): Promise<GetEthAppNameAndVersionResponse>;
@@ -175,7 +176,7 @@ export class LedgerMobileBridge implements LedgerMobileBridge {
   }
 
   getDeviceId(): string {
-    return this.#deviceId
+    return this.#deviceId;
   }
 
   setDeviceId(deviceId: string): void {

--- a/src/ledger-mobile-bridge.ts
+++ b/src/ledger-mobile-bridge.ts
@@ -148,7 +148,7 @@ export class LedgerTransportMiddleware implements LedgerTransportMiddleware {
 export class LedgerMobileBridge implements LedgerMobileBridge {
   #transportMiddleware?: LedgerTransportMiddleware;
 
-  deviceId = '';
+  #deviceId = '';
 
   isDeviceConnected = false;
 
@@ -156,7 +156,7 @@ export class LedgerMobileBridge implements LedgerMobileBridge {
     transportMiddleware: LedgerTransportMiddleware,
     opts?: LedgerMobileBridgeOptions,
   ) {
-    this.deviceId = opts?.deviceId ?? '';
+    this.#deviceId = opts?.deviceId ?? '';
     this.#transportMiddleware = transportMiddleware;
   }
 
@@ -174,24 +174,16 @@ export class LedgerMobileBridge implements LedgerMobileBridge {
     this.isDeviceConnected = true;
   }
 
-  async getEthAppNameAndVersion(): Promise<GetEthAppNameAndVersionResponse> {
-    return await this.getTransportMiddleWare().getEthAppNameAndVersion();
-  }
-
-  async openEthApp(): Promise<void> {
-    await this.getTransportMiddleWare().openEthApp();
-  }
-
-  async closeApps(): Promise<void> {
-    await this.getTransportMiddleWare().closeApps();
+  getDeviceId(): string {
+    return this.#deviceId
   }
 
   setDeviceId(deviceId: string): void {
     if (deviceId) {
-      if (this.deviceId && this.deviceId !== deviceId) {
+      if (this.#deviceId && this.#deviceId !== deviceId) {
         throw new Error('deviceId mismatch.');
       }
-      this.deviceId = deviceId;
+      this.#deviceId = deviceId;
     }
   }
 
@@ -216,23 +208,23 @@ export class LedgerMobileBridge implements LedgerMobileBridge {
   }
 
   async forgetDevice(): Promise<void> {
-    this.deviceId = '';
+    this.#deviceId = '';
     this.isDeviceConnected = false;
   }
 
   async deserializeData(serializeData: Record<string, unknown>): Promise<void> {
-    this.deviceId = (serializeData.deviceId as string) ?? this.deviceId;
+    this.#deviceId = (serializeData.deviceId as string) ?? this.#deviceId;
   }
 
   async serializeData(): Promise<Record<string, unknown>> {
     return {
-      deviceId: this.deviceId,
+      deviceId: this.#deviceId,
     };
   }
 
   async getOptions(): Promise<LedgerMobileBridgeOptions> {
     return {
-      deviceId: this.deviceId,
+      deviceId: this.#deviceId,
     };
   }
 
@@ -275,5 +267,17 @@ export class LedgerMobileBridge implements LedgerMobileBridge {
   }: GetPublicKeyParams): Promise<GetPublicKeyResponse> {
     const app = await this.getTransportMiddleWare().getEthApp();
     return app.getAddress(hdPath, false, true);
+  }
+
+  async getEthAppNameAndVersion(): Promise<GetEthAppNameAndVersionResponse> {
+    return await this.getTransportMiddleWare().getEthAppNameAndVersion();
+  }
+
+  async openEthApp(): Promise<void> {
+    await this.getTransportMiddleWare().openEthApp();
+  }
+
+  async closeApps(): Promise<void> {
+    await this.getTransportMiddleWare().closeApps();
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1601,6 +1601,7 @@ __metadata:
     "@ethereumjs/util": ^8.0.0
     "@lavamoat/allow-scripts": ^2.3.0
     "@ledgerhq/hw-app-eth": ^6.32.0
+    "@ledgerhq/hw-transport": ^6.28.8
     "@ledgerhq/types-cryptoassets": ^7.6.0
     "@ledgerhq/types-devices": ^6.22.4
     "@metamask/auto-changelog": ^3.1.0

--- a/yarn.lock
+++ b/yarn.lock
@@ -1318,10 +1318,29 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@ledgerhq/devices@npm:^8.0.7":
+  version: 8.0.7
+  resolution: "@ledgerhq/devices@npm:8.0.7"
+  dependencies:
+    "@ledgerhq/errors": ^6.14.0
+    "@ledgerhq/logs": ^6.10.1
+    rxjs: 6
+    semver: ^7.3.5
+  checksum: 9dff60fc6b443d38a508e3f83b0ee3989fd58061c59345dd6ded524b5fd01b9a2840eb9bde7979829ae6d50d8e0c0e552e21284a1f10d8636a11ed737ca464a2
+  languageName: node
+  linkType: hard
+
 "@ledgerhq/errors@npm:^6.12.3":
   version: 6.12.3
   resolution: "@ledgerhq/errors@npm:6.12.3"
   checksum: 3284cbc85dc2df24f17a6e3899eb5afdff96e63d073b5914906c45ed8f1a93c7daa1e2b847d621610a1088b63c0abb9379e6b6ca395144c2d50855a4606c1d3f
+  languageName: node
+  linkType: hard
+
+"@ledgerhq/errors@npm:^6.14.0":
+  version: 6.14.0
+  resolution: "@ledgerhq/errors@npm:6.14.0"
+  checksum: 2c4e7bf126952a781d9226752b9401e842a5a773861128d182e9f40f1f46bf6cd8667c2ca64a1c52254d151bc6bec6d85ea62ba8b3dd35e46bbe47a90c291830
   languageName: node
   linkType: hard
 
@@ -1361,6 +1380,17 @@ __metadata:
     "@ledgerhq/errors": ^6.12.3
     events: ^3.3.0
   checksum: 69bf0f72e112c0c2f538c66d0b1dd2b24b19f1fcf5d671fdcfd50838e86dc55702555e0c639bbc55889a42a8ebd07243ad31798c2ff237dc21a1573581caf5ab
+  languageName: node
+  linkType: hard
+
+"@ledgerhq/hw-transport@npm:^6.28.8":
+  version: 6.28.8
+  resolution: "@ledgerhq/hw-transport@npm:6.28.8"
+  dependencies:
+    "@ledgerhq/devices": ^8.0.7
+    "@ledgerhq/errors": ^6.14.0
+    events: ^3.3.0
+  checksum: 636a1d8229e10673745a322ed4714f85ef395c8bdf39ed14bef859fbc8132ee271a2cf164042a06d7a4d24ee0bbb77c6c29e15c950b3f58af53ad161f9854c51
   languageName: node
   linkType: hard
 
@@ -1452,6 +1482,7 @@ __metadata:
     "@ethereumjs/tx": ^4.1.1
     "@lavamoat/allow-scripts": ^2.3.0
     "@ledgerhq/hw-app-eth": ^6.32.0
+    "@ledgerhq/hw-transport": ^6.28.8
     "@metamask/auto-changelog": ^3.1.0
     "@metamask/eslint-config": ^11.0.1
     "@metamask/eslint-config-browser": ^11.0.0


### PR DESCRIPTION
- add mobile bridge
- decouple the transport middleware from the bridge, for mobile, the transport middleware is a interface to connect to ledger eth app and the transport layer; for desktop, it is refer to iframe
- adding setter / getter method for metadata from the bridge as a generic method to store different data on different bridge, hence the serialize and deserialize method from the highlevel module will serialize/deserialize the metadata together with the low level module (bridge)
- move bridgeUrl into low level module (bridge)
- enhance time complexity in deserialize, #migrateAccountDetails method by use Set, rather than array include
- reduce the number of traversal in  removeAccount
- remove exportAccount due to eth keyring has throw an exception, should not create another exception type