### PR TITLE
chore: move @metamask/utils from dependencies to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
     "@ethereumjs/tx": "^4.1.1",
     "@ethereumjs/util": "^8.0.0",
     "@metamask/eth-sig-util": "^7.0.0",
-    "@metamask/utils": "^8.2.0",
     "hdkey": "^2.1.0"
   },
   "devDependencies": {
@@ -56,6 +55,7 @@
     "@metamask/eslint-config-jest": "^11.0.0",
     "@metamask/eslint-config-nodejs": "^11.0.0",
     "@metamask/eslint-config-typescript": "^11.0.0",
+    "@metamask/utils": "^8.2.0",
     "@types/ethereumjs-tx": "^1.0.1",
     "@types/hdkey": "^2.0.1",
     "@types/jest": "^28.1.6",


### PR DESCRIPTION
The package `@metamask/utils` is only directly used in tests and does not need to be in `dependencies`. This moves it to `devDependencies`.

It became unused as of #156 .