### PR TITLE
fix: invalid rlp data for legacy transactions

### DIFF
--- a/src/ledger-keyring.test.ts
+++ b/src/ledger-keyring.test.ts
@@ -545,7 +545,9 @@ describe('LedgerKeyring', function () {
           .mockImplementation(async (params) => {
             expect(params).toStrictEqual({
               hdPath: "m/44'/60'/0'/0",
-              tx: RLP.encode(newFakeTx.getMessageToSign(false)).toString(),
+              tx: Buffer.from(
+                RLP.encode(newFakeTx.getMessageToSign(false)),
+              ).toString('hex'),
             });
             return expectedRSV;
           });

--- a/src/ledger-keyring.ts
+++ b/src/ledger-keyring.ts
@@ -340,7 +340,7 @@ export class LedgerKeyring extends EventEmitter {
 
     rawTxHex = Buffer.isBuffer(messageToSign)
       ? messageToSign.toString('hex')
-      : RLP.encode(messageToSign).toString();
+      : Buffer.from(RLP.encode(messageToSign)).toString('hex');
 
     return this.#signTransaction(address, rawTxHex, (payload) => {
       // Because tx will be immutable, first get a plain javascript object that


### PR DESCRIPTION
[This commit](https://github.com/MetaMask/eth-ledger-bridge-keyring/commit/30ddc3a0efdf9d7437a44c42e1273fb2d1616da2#diff-6ee7a1e694bb4c08ef94227ea86ffa68876dbe503d3045565ed906b27910bccfR337) introduced a bug with legacy transactions.

With `@ethereumjs/rlp`, `RLP.encode(..)` returns a `Uint8Array`, and `Uint8Array.toString()` does not return a hex value as we expect in the code. 

This PR converts the returned `Uint8Array` into a `Buffer`, and then into a hex string.

See https://github.com/MetaMask/metamask-extension/issues/22118