### PR TITLE
feat: add mobile keyring bridge

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -41,10 +41,10 @@ module.exports = {
   // An object that configures minimum threshold enforcement for coverage results
   coverageThreshold: {
     global: {
-      branches: 69.76,
-      functions: 88.73,
-      lines: 81.93,
-      statements: 81.84,
+      branches: 70.74,
+      functions: 89.36,
+      lines: 83.83,
+      statements: 83.74,
     },
   },
 

--- a/jest.config.js
+++ b/jest.config.js
@@ -41,10 +41,10 @@ module.exports = {
   // An object that configures minimum threshold enforcement for coverage results
   coverageThreshold: {
     global: {
-      branches: 70.74,
-      functions: 89.36,
-      lines: 83.83,
-      statements: 83.74,
+      branches: 72.78,
+      functions: 89.47,
+      lines: 83.71,
+      statements: 83.62,
     },
   },
 

--- a/package.json
+++ b/package.json
@@ -40,13 +40,14 @@
     "@ethereumjs/rlp": "^4.0.0",
     "@ethereumjs/tx": "^4.1.1",
     "@ethereumjs/util": "^8.0.0",
+    "@ledgerhq/hw-app-eth": "^6.32.0",
+    "@ledgerhq/hw-transport": "^6.28.8",
     "@metamask/eth-sig-util": "^7.0.0",
     "hdkey": "^2.1.0"
   },
   "devDependencies": {
     "@ethereumjs/common": "^3.1.1",
     "@lavamoat/allow-scripts": "^2.5.1",
-    "@ledgerhq/hw-app-eth": "^6.32.0",
     "@ledgerhq/types-cryptoassets": "^7.6.0",
     "@ledgerhq/types-devices": "^6.22.4",
     "@metamask/auto-changelog": "^3.1.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,5 @@
 export * from './ledger-keyring';
 export * from './ledger-iframe-bridge';
+export * from './ledger-mobile-bridge';
+export * from './ledger-mobile-bridge/index';
 export * from './ledger-bridge';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 export * from './ledger-keyring';
 export * from './ledger-iframe-bridge';
 export * from './ledger-mobile-bridge';
-export * from './ledger-mobile-bridge/index';
+export * from './ledger-mobile-bridge/';
 export * from './ledger-bridge';

--- a/src/ledger-bridge.ts
+++ b/src/ledger-bridge.ts
@@ -1,11 +1,10 @@
 import type LedgerHwAppEth from '@ledgerhq/hw-app-eth';
+import { Transport } from '@ledgerhq/types-devices';
 
 export type GetPublicKeyParams = { hdPath: string };
 export type GetPublicKeyResponse = Awaited<
   ReturnType<LedgerHwAppEth['getAddress']>
-> & {
-  chainCode: string;
-};
+>;
 
 export type LedgerSignTransactionParams = { hdPath: string; tx: string };
 export type LedgerSignTransactionResponse = Awaited<
@@ -49,7 +48,7 @@ export type LedgerBridge<T extends LedgerBridgeOptions> = {
 
   attemptMakeApp(): Promise<boolean>;
 
-  updateTransportMethod(transportType: string): Promise<boolean>;
+  updateTransportMethod(transportType: string | Transport): Promise<boolean>;
 
   getPublicKey(params: GetPublicKeyParams): Promise<GetPublicKeyResponse>;
 

--- a/src/ledger-mobile-bridge.test.ts
+++ b/src/ledger-mobile-bridge.test.ts
@@ -184,7 +184,9 @@ describe('LedgerMobileBridge', function () {
       mockTransport.deviceModel.id = '';
       await expect(
         bridge.updateTransportMethod(mockTransport as unknown as Transport),
-      ).rejects.toThrow('device id is not defined.');
+      ).rejects.toThrow(
+        'Property `deviceModel.id` is not defined in `transport`.',
+      );
     });
   });
 

--- a/src/ledger-mobile-bridge.test.ts
+++ b/src/ledger-mobile-bridge.test.ts
@@ -9,21 +9,13 @@ import {
 
 const DEVICE_ID = 'DEVICE_ID';
 
-const mockTransport = {
-  deviceModel: {
-    id: DEVICE_ID,
-  },
-  send: jest.fn(),
-  close: jest.fn(),
-  decorateAppAPIMethods: jest.fn(),
-};
-
 describe('LedgerMobileBridge', function () {
   let bridge: LedgerMobileBridge;
   let transportMiddleware: LedgerTransportMiddleware;
   let transportMiddlewareDisposeSpy: jest.SpyInstance;
   let transportMiddlewareSetTransportSpy: jest.SpyInstance;
   let transportMiddlewareGetEthAppSpy: jest.SpyInstance;
+
   const mockEthApp = {
     signEIP712HashedMessage: jest.fn(),
     signTransaction: jest.fn(),
@@ -32,6 +24,15 @@ describe('LedgerMobileBridge', function () {
     openEthApp: jest.fn(),
     closeApps: jest.fn(),
     getAppNameAndVersion: jest.fn(),
+  };
+
+  const mockTransport = {
+    deviceModel: {
+      id: DEVICE_ID,
+    },
+    send: jest.fn(),
+    close: jest.fn(),
+    decorateAppAPIMethods: jest.fn(),
   };
 
   beforeEach(async function () {
@@ -169,32 +170,13 @@ describe('LedgerMobileBridge', function () {
     });
   });
 
-  describe('deserializeData', function () {
-    it('serializes what it deserializes', async function () {
-      await bridge.deserializeData({ deviceId: 'ABC' });
-      const data = await bridge.serializeData();
-      expect(data).toHaveProperty('deviceId', 'ABC');
-    });
-  });
-
-  describe('serializeData', function () {
-    it('serializes an instance', async function () {
-      await bridge.deserializeData({ deviceId: DEVICE_ID });
-      const result = await bridge.serializeData();
-      expect(result).toStrictEqual({
-        deviceId: DEVICE_ID,
-      });
-    });
-  });
-
   describe('updateTransportMethod', function () {
-    it('updateTransportMethod with correct parameters', async function () {
+    it('set transport in transportMiddleware and set isDeviceConnected to true', async function () {
       await bridge.updateTransportMethod(mockTransport as unknown as Transport);
       expect(transportMiddlewareSetTransportSpy).toHaveBeenCalledTimes(1);
       expect(transportMiddlewareSetTransportSpy).toHaveBeenCalledWith(
         mockTransport,
       );
-      expect(await bridge.getOptions()).toHaveProperty('deviceId', DEVICE_ID);
       expect(bridge.isDeviceConnected).toBe(true);
     });
 
@@ -227,27 +209,10 @@ describe('LedgerMobileBridge', function () {
     });
   });
 
-  describe('setOption', function () {
-    it('option set correctly', async function () {
-      await bridge.setOptions({ deviceId: 'DEF' });
-      expect(await bridge.getOptions()).toHaveProperty('deviceId', 'DEF');
-    });
-
-    it('throw error when device id has set but different device id given', async function () {
-      await bridge.setOptions({ deviceId: DEVICE_ID });
-      await expect(
-        bridge.setOptions({ deviceId: 'another id' }),
-      ).rejects.toThrow('deviceId mismatch.');
-    });
-  });
-
   describe('getOption', function () {
     it('return instance options', async function () {
-      await bridge.setOptions({ deviceId: DEVICE_ID });
       const result = await bridge.getOptions();
-      expect(result).toStrictEqual({
-        deviceId: DEVICE_ID,
-      });
+      expect(result).toStrictEqual({});
     });
   });
 });

--- a/src/ledger-mobile-bridge.test.ts
+++ b/src/ledger-mobile-bridge.test.ts
@@ -1,0 +1,253 @@
+import ledgerService from '@ledgerhq/hw-app-eth/lib/services/ledger';
+import Transport from '@ledgerhq/hw-transport';
+
+import { LedgerMobileBridge } from './ledger-mobile-bridge';
+import {
+  LedgerTransportMiddleware,
+  MetaMaskLedgerHwAppEth,
+} from './ledger-mobile-bridge/';
+
+const DEVICE_ID = 'DEVICE_ID';
+
+const mockTransport = {
+  deviceModel: {
+    id: DEVICE_ID,
+  },
+  send: jest.fn(),
+  close: jest.fn(),
+  decorateAppAPIMethods: jest.fn(),
+};
+
+describe('LedgerMobileBridge', function () {
+  let bridge: LedgerMobileBridge;
+  let transportMiddleware: LedgerTransportMiddleware;
+  let transportMiddlewareDisposeSpy: jest.SpyInstance;
+  let transportMiddlewareSetTransportSpy: jest.SpyInstance;
+  let transportMiddlewareGetEthAppSpy: jest.SpyInstance;
+  const mockEthApp = {
+    signEIP712HashedMessage: jest.fn(),
+    signTransaction: jest.fn(),
+    getAddress: jest.fn(),
+    signPersonalMessage: jest.fn(),
+    openEthApp: jest.fn(),
+    closeApps: jest.fn(),
+    getAppNameAndVersion: jest.fn(),
+  };
+
+  beforeEach(async function () {
+    transportMiddleware = new LedgerTransportMiddleware();
+    transportMiddlewareDisposeSpy = jest
+      .spyOn(transportMiddleware, 'dispose')
+      .mockImplementation(async () => Promise.resolve());
+    transportMiddlewareSetTransportSpy = jest.spyOn(
+      transportMiddleware,
+      'setTransport',
+    );
+    transportMiddlewareGetEthAppSpy = jest
+      .spyOn(transportMiddleware, 'getEthApp')
+      .mockImplementation(
+        () => mockEthApp as unknown as MetaMaskLedgerHwAppEth,
+      );
+    bridge = new LedgerMobileBridge(transportMiddleware);
+  });
+
+  afterEach(function () {
+    jest.clearAllMocks();
+    mockTransport.deviceModel.id = DEVICE_ID;
+  });
+
+  describe('destroy', function () {
+    it('trigger middleware dispose', async function () {
+      await bridge.updateTransportMethod(mockTransport as unknown as Transport);
+      expect(bridge.isDeviceConnected).toBe(true);
+      await bridge.destroy();
+      expect(transportMiddlewareDisposeSpy).toHaveBeenCalledTimes(1);
+      expect(bridge.isDeviceConnected).toBe(false);
+    });
+
+    it('does not throw error when it is not connected', async function () {
+      let result = null;
+      try {
+        await bridge.destroy();
+      } catch (error) {
+        result = error;
+      } finally {
+        expect(result).toBeNull();
+        expect(transportMiddlewareDisposeSpy).toHaveBeenCalledTimes(1);
+        expect(bridge.isDeviceConnected).toBe(false);
+      }
+    });
+  });
+
+  describe('attemptMakeApp', function () {
+    it('throw error not supported', async function () {
+      await expect(bridge.attemptMakeApp()).rejects.toThrow(
+        'Method not supported.',
+      );
+    });
+  });
+
+  describe('deviceSignMessage', function () {
+    it('sends and processes a successful ledger-sign-personal-message message', async function () {
+      const hdPath = "m/44'/60'/0'/0/0";
+      const message = 'message';
+      await bridge.deviceSignMessage({
+        hdPath,
+        message,
+      });
+      expect(transportMiddlewareGetEthAppSpy).toHaveBeenCalledTimes(1);
+      expect(mockEthApp.signPersonalMessage).toHaveBeenCalledTimes(1);
+      expect(mockEthApp.signPersonalMessage).toHaveBeenCalledWith(
+        hdPath,
+        message,
+      );
+    });
+  });
+
+  describe('getPublicKey', function () {
+    it('sends and processes a successful ledger-unlock message', async function () {
+      const hdPath = "m/44'/60'/0'/0/0";
+      await bridge.getPublicKey({
+        hdPath,
+      });
+      expect(transportMiddlewareGetEthAppSpy).toHaveBeenCalledTimes(1);
+      expect(mockEthApp.getAddress).toHaveBeenCalledTimes(1);
+      expect(mockEthApp.getAddress).toHaveBeenCalledWith(hdPath, false, true);
+    });
+  });
+
+  describe('deviceSignTransaction', function () {
+    it('sends and processes a successful ledger-sign-transaction message', async function () {
+      const hdPath = "m/44'/60'/0'/0/0";
+      const tx =
+        'f86d8202b38477359400825208944592d8f8d7b001e72cb26a73e4fa1806a51ac79d880de0b6b3a7640000802ba0699ff162205967ccbabae13e07cdd4284258d46ec1051a70a51be51ec2bc69f3a04e6944d508244ea54a62ebf9a72683eeadacb73ad7c373ee542f1998147b220e';
+      const resolution = await ledgerService.resolveTransaction(tx, {}, {});
+      await bridge.deviceSignTransaction({
+        hdPath,
+        tx,
+      });
+      expect(transportMiddlewareGetEthAppSpy).toHaveBeenCalledTimes(1);
+      expect(mockEthApp.signTransaction).toHaveBeenCalledTimes(1);
+      expect(mockEthApp.signTransaction).toHaveBeenCalledWith(
+        hdPath,
+        tx,
+        resolution,
+      );
+    });
+
+    it('throws an error when tx format is not correct', async function () {
+      const hdPath = "m/44'/60'/0'/0/0";
+      const tx = '';
+      await expect(
+        bridge.deviceSignTransaction({
+          hdPath,
+          tx,
+        }),
+      ).rejects.toThrow(Error);
+      expect(transportMiddlewareGetEthAppSpy).toHaveBeenCalledTimes(0);
+      expect(mockEthApp.signTransaction).toHaveBeenCalledTimes(0);
+    });
+  });
+
+  describe('deviceSignTypedData', function () {
+    it('sends and processes a successful ledger-sign-typed-data message', async function () {
+      const hdPath = "m/44'/60'/0'/0/0";
+      const domainSeparatorHex = 'domainSeparatorHex';
+      const hashStructMessageHex = 'hashStructMessageHex';
+      await bridge.deviceSignTypedData({
+        hdPath,
+        domainSeparatorHex,
+        hashStructMessageHex,
+      });
+      expect(transportMiddlewareGetEthAppSpy).toHaveBeenCalledTimes(1);
+      expect(mockEthApp.signEIP712HashedMessage).toHaveBeenCalledTimes(1);
+      expect(mockEthApp.signEIP712HashedMessage).toHaveBeenCalledWith(
+        hdPath,
+        domainSeparatorHex,
+        hashStructMessageHex,
+      );
+    });
+  });
+
+  describe('deserializeData', function () {
+    it('serializes what it deserializes', async function () {
+      await bridge.deserializeData({ deviceId: 'ABC' });
+      const data = await bridge.serializeData();
+      expect(data).toHaveProperty('deviceId', 'ABC');
+    });
+  });
+
+  describe('serializeData', function () {
+    it('serializes an instance', async function () {
+      await bridge.deserializeData({ deviceId: DEVICE_ID });
+      const result = await bridge.serializeData();
+      expect(result).toStrictEqual({
+        deviceId: DEVICE_ID,
+      });
+    });
+  });
+
+  describe('updateTransportMethod', function () {
+    it('updateTransportMethod with correct parameters', async function () {
+      await bridge.updateTransportMethod(mockTransport as unknown as Transport);
+      expect(transportMiddlewareSetTransportSpy).toHaveBeenCalledTimes(1);
+      expect(transportMiddlewareSetTransportSpy).toHaveBeenCalledWith(
+        mockTransport,
+      );
+      expect(await bridge.getOptions()).toHaveProperty('deviceId', DEVICE_ID);
+      expect(bridge.isDeviceConnected).toBe(true);
+    });
+
+    it('throw error when device id not set from transport', async function () {
+      mockTransport.deviceModel.id = '';
+      await expect(
+        bridge.updateTransportMethod(mockTransport as unknown as Transport),
+      ).rejects.toThrow('device id is not defined.');
+    });
+  });
+
+  describe('openEthApp', function () {
+    it('transport command should send correctly', async function () {
+      await bridge.openEthApp();
+      expect(mockEthApp.openEthApp).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('closeApps', function () {
+    it('transport command should send correctly', async function () {
+      await bridge.closeApps();
+      expect(mockEthApp.closeApps).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('getAppNameAndVersion', function () {
+    it('transport command should send correctly', async function () {
+      await bridge.getAppNameAndVersion();
+      expect(mockEthApp.getAppNameAndVersion).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('setOption', function () {
+    it('option set correctly', async function () {
+      await bridge.setOptions({ deviceId: 'DEF' });
+      expect(await bridge.getOptions()).toHaveProperty('deviceId', 'DEF');
+    });
+
+    it('throw error when device id has set but different device id given', async function () {
+      await bridge.setOptions({ deviceId: DEVICE_ID });
+      await expect(
+        bridge.setOptions({ deviceId: 'another id' }),
+      ).rejects.toThrow('deviceId mismatch.');
+    });
+  });
+
+  describe('getOption', function () {
+    it('return instance options', async function () {
+      await bridge.setOptions({ deviceId: DEVICE_ID });
+      const result = await bridge.getOptions();
+      expect(result).toStrictEqual({
+        deviceId: DEVICE_ID,
+      });
+    });
+  });
+});

--- a/src/ledger-mobile-bridge.ts
+++ b/src/ledger-mobile-bridge.ts
@@ -1,0 +1,250 @@
+import ledgerService from '@ledgerhq/hw-app-eth/lib/services/ledger';
+import type Transport from '@ledgerhq/hw-transport';
+
+// eslint-disable-next-line import/no-nodejs-modules
+import {
+  GetPublicKeyParams,
+  GetPublicKeyResponse,
+  LedgerBridge,
+  LedgerSignMessageParams,
+  LedgerSignMessageResponse,
+  LedgerSignTransactionParams,
+  LedgerSignTransactionResponse,
+  LedgerSignTypedDataParams,
+  LedgerSignTypedDataResponse,
+  LedgerBridgeSerializeData,
+} from './ledger-bridge';
+import {
+  GetAppNameAndVersionResponse,
+  LedgerMobileBridgeOptions,
+  TransportMiddleware,
+} from './ledger-mobile-bridge/';
+
+// eslint-disable-next-line @typescript-eslint/consistent-type-definitions
+export interface LedgerMobileBridge {
+  getAppNameAndVersion(): Promise<GetAppNameAndVersionResponse>;
+  openEthApp(): Promise<void>;
+  closeApps(): Promise<void>;
+}
+
+/**
+ * LedgerMobileBridge is a bridge between the LedgerKeyring and the LedgerTransportMiddleware.
+ */
+export class LedgerMobileBridge
+  implements LedgerBridge<LedgerMobileBridgeOptions>, LedgerMobileBridge
+{
+  #transportMiddleware?: TransportMiddleware;
+
+  #deviceId = '';
+
+  isDeviceConnected = false;
+
+  constructor(
+    transportMiddleware: TransportMiddleware,
+    opts?: LedgerMobileBridgeOptions,
+  ) {
+    this.#deviceId = opts?.deviceId ?? '';
+    this.#transportMiddleware = transportMiddleware;
+  }
+
+  /**
+   * Method to initializes the keyring.
+   * Mobile ledger doesnt not require init.
+   */
+  async init(): Promise<void> {
+    return Promise.resolve();
+  }
+
+  /**
+   * Method to destroy the keyring.
+   * Set isDeviceConnected to false. and dispose the transport.
+   */
+  async destroy(): Promise<void> {
+    try {
+      await this.#getTransportMiddleWare().dispose();
+    } catch (error) {
+      // eslint-disable-next-line no-console
+      console.error(error);
+    }
+    this.isDeviceConnected = false;
+  }
+
+  /**
+   * Method to sign a string Message.
+   * Sending the string message to the device and returning the signed message.
+   *
+   * @param params - The descriptor to open the transport with.
+   * @param params.hdPath - The descriptor to open the transport with.
+   * @param params.message - An optional timeout for the transport connection.
+   * @returns A promise that resolves with a Transport instance.
+   */
+  async deviceSignMessage({
+    hdPath,
+    message,
+  }: LedgerSignMessageParams): Promise<LedgerSignMessageResponse> {
+    const app = this.#getTransportMiddleWare().getEthApp();
+    return app.signPersonalMessage(hdPath, message);
+  }
+
+  /**
+   * Method to sign a EIP712 Message.
+   * Sending the typed data message to the device and returning the signed message.
+   *
+   * @param params - An object contains hdPath, domainSeparatorHex and hashStructMessageHex.
+   * @param params.hdPath - The BIP 32 path of the account.
+   * @param params.domainSeparatorHex - The domain separator.
+   * @param params.hashStructMessageHex - The hashed struct message.
+   */
+  async deviceSignTypedData({
+    hdPath,
+    domainSeparatorHex,
+    hashStructMessageHex,
+  }: LedgerSignTypedDataParams): Promise<LedgerSignTypedDataResponse> {
+    const app = this.#getTransportMiddleWare().getEthApp();
+    return app.signEIP712HashedMessage(
+      hdPath,
+      domainSeparatorHex,
+      hashStructMessageHex,
+    );
+  }
+
+  /**
+   * Method to sign a transaction
+   * Sending the hexadecimal transaction message to the device and returning the signed transaction.
+   *
+   * @param params - An object contains tx, hdPath.
+   * @param params.tx - The raw ethereum transaction in hexadecimal to sign.
+   * @param params.hdPath - The BIP 32 path of the account.
+   */
+  async deviceSignTransaction({
+    tx,
+    hdPath,
+  }: LedgerSignTransactionParams): Promise<LedgerSignTransactionResponse> {
+    const resolution = await ledgerService.resolveTransaction(tx, {}, {});
+    const app = this.#getTransportMiddleWare().getEthApp();
+    return app.signTransaction(hdPath, tx, resolution);
+  }
+
+  /**
+   * Method to deserialize metadata from ledger mobile bridge.
+   *
+   * @param serializeData - An object contains serialized data.
+   */
+  async deserializeData(
+    serializeData: LedgerBridgeSerializeData,
+  ): Promise<void> {
+    this.#deviceId = (serializeData.deviceId as string) ?? this.#deviceId;
+  }
+
+  /**
+   * Method to return the serialized metadata from ledger mobile bridge.
+   */
+  async serializeData(): Promise<LedgerBridgeSerializeData> {
+    return {
+      deviceId: this.#deviceId,
+    };
+  }
+
+  /**
+   * Method to get Ethereum address for a given BIP 32 path.
+   *
+   * @param params - An object contains hdPath.
+   * @param params.hdPath - The BIP 32 path of the account.
+   */
+  async getPublicKey({
+    hdPath,
+  }: GetPublicKeyParams): Promise<GetPublicKeyResponse> {
+    const app = this.#getTransportMiddleWare().getEthApp();
+    return await app.getAddress(hdPath, false, true);
+  }
+
+  /**
+   * Method to get the current configuration of the ledger bridge keyring.
+   */
+  async getOptions(): Promise<LedgerMobileBridgeOptions> {
+    return {
+      deviceId: this.#deviceId,
+    };
+  }
+
+  /**
+   * Method to set the current configuration of the ledger bridge keyring.
+   *
+   * @param opts - An object contains deviceId.
+   * @param opts.deviceId - The mobile device Id.
+   */
+  async setOptions(opts: LedgerMobileBridgeOptions): Promise<void> {
+    if (opts.deviceId) {
+      if (this.#deviceId && this.#deviceId !== opts.deviceId) {
+        throw new Error('setOptions: deviceId mismatch.');
+      }
+      this.#deviceId = opts.deviceId;
+    }
+  }
+
+  /**
+   * Method set the transport object to communicate with the device.
+   * The transport object will be passed to underlying middleware.
+   *
+   * @param transport - The generic interface for communicating with a Ledger hardware wallet. There are different kind of transports based on the technology (channels like U2F, HID, Bluetooth, Webusb).
+   */
+  async updateTransportMethod(transport: Transport): Promise<boolean> {
+    if (!transport.deviceModel?.id) {
+      throw new Error('updateTransportMethod: device id is not defined.');
+    }
+    this.#getTransportMiddleWare().setTransport(transport);
+    await this.setOptions({
+      deviceId: transport.deviceModel.id,
+    });
+    this.isDeviceConnected = true;
+    return true;
+  }
+
+  /**
+   * Method to init eth app object on ledger device.
+   * This method is not supported on mobile.
+   */
+  async attemptMakeApp(): Promise<boolean> {
+    throw new Error('attemptMakeApp: Method not supported.');
+  }
+
+  /**
+   * Method to open Ethereum application on ledger device.
+   *
+   */
+  async openEthApp(): Promise<void> {
+    const app = this.#getTransportMiddleWare().getEthApp();
+    await app.openEthApp();
+  }
+
+  /**
+   * Method to close all running application on ledger device.
+   *
+   */
+  async closeApps(): Promise<void> {
+    const app = this.#getTransportMiddleWare().getEthApp();
+    await app.closeApps();
+  }
+
+  /**
+   * Method to get running application name and version on ledger device.
+   */
+  async getAppNameAndVersion(): Promise<GetAppNameAndVersionResponse> {
+    const app = this.#getTransportMiddleWare().getEthApp();
+    return app.getAppNameAndVersion();
+  }
+
+  /**
+   * Method to get Transport MiddleWare object.
+   *
+   * @returns The TransportMiddleware object.
+   */
+  #getTransportMiddleWare(): TransportMiddleware {
+    if (this.#transportMiddleware) {
+      return this.#transportMiddleware;
+    }
+    throw new Error(
+      'getTransportMiddleWare: transportMiddleware is not initialized.',
+    );
+  }
+}

--- a/src/ledger-mobile-bridge.ts
+++ b/src/ledger-mobile-bridge.ts
@@ -57,7 +57,7 @@ export class LedgerMobileBridge
 
   /**
    * Method to destroy the keyring.
-   * Set isDeviceConnected to false. and dispose the transport.
+   * It will dispose the transportmiddleware and set isDeviceConnected to false.
    */
   async destroy(): Promise<void> {
     try {
@@ -76,7 +76,7 @@ export class LedgerMobileBridge
    * @param params - The descriptor to open the transport with.
    * @param params.hdPath - The descriptor to open the transport with.
    * @param params.message - An optional timeout for the transport connection.
-   * @returns A promise that resolves with a Transport instance.
+   * @returns Retrieve v, r, s from the signed message.
    */
   async deviceSignMessage({
     hdPath,
@@ -93,6 +93,7 @@ export class LedgerMobileBridge
    * @param params.hdPath - The BIP 32 path of the account.
    * @param params.domainSeparatorHex - The domain separator.
    * @param params.hashStructMessageHex - The hashed struct message.
+   * @returns Retrieve v, r, s from the signed message.
    */
   async deviceSignTypedData({
     hdPath,
@@ -113,6 +114,7 @@ export class LedgerMobileBridge
    * @param params - An object contains tx, hdPath.
    * @param params.tx - The raw ethereum transaction in hexadecimal to sign.
    * @param params.hdPath - The BIP 32 path of the account.
+   * @returns Retrieve v, r, s from the signed transaction.
    */
   async deviceSignTransaction({
     tx,
@@ -123,10 +125,11 @@ export class LedgerMobileBridge
   }
 
   /**
-   * Method to get Ethereum address for a given BIP 32 path.
+   * Method to retrieve the ethereum address for a given BIP 32 path.
    *
    * @param params - An object contains hdPath.
    * @param params.hdPath - The BIP 32 path of the account.
+   * @returns An object contains publicKey, address and chainCode.
    */
   async getPublicKey({
     hdPath,
@@ -135,14 +138,16 @@ export class LedgerMobileBridge
   }
 
   /**
-   * Method to get the current configuration of the ledger bridge keyring.
+   * Method to retrieve the current configuration.
+   *
+   * @returns Retrieve current configuration.
    */
   async getOptions(): Promise<LedgerMobileBridgeOptions> {
     return this.#opts;
   }
 
   /**
-   * Method to set the current configuration of the ledger bridge keyring.
+   * Method to set the current configuration.
    *
    * @param opts - An configuration object.
    */
@@ -151,10 +156,10 @@ export class LedgerMobileBridge
   }
 
   /**
-   * Method set the transport object to communicate with the device.
-   * The transport object will be passed to underlying middleware.
+   * Method to set the transport object to communicate with the device.
    *
    * @param transport - The communication interface with the Ledger hardware wallet. There are different kind of transports based on the technology (channels like U2F, HID, Bluetooth, Webusb).
+   * @returns Retrieve boolean.
    */
   async updateTransportMethod(transport: Transport): Promise<boolean> {
     if (!transport.deviceModel?.id) {
@@ -176,7 +181,7 @@ export class LedgerMobileBridge
   }
 
   /**
-   * Method to open Ethereum application on ledger device.
+   * Method to open ethereum application on ledger device.
    *
    */
   async openEthApp(): Promise<void> {
@@ -192,14 +197,16 @@ export class LedgerMobileBridge
   }
 
   /**
-   * Method to get running application name and version on ledger device.
+   * Method to retrieve the name and version of the running application in ledger device.
+   *
+   * @returns An object contains appName and version.
    */
   async getAppNameAndVersion(): Promise<GetAppNameAndVersionResponse> {
     return this.#getEthApp().getAppNameAndVersion();
   }
 
   /**
-   * Method to get Transport MiddleWare object.
+   * Method to retrieve the transport middleWare object.
    *
    * @returns The TransportMiddleware object.
    */
@@ -211,7 +218,7 @@ export class LedgerMobileBridge
   }
 
   /**
-   * Method to get ledger Eth App.
+   * Method to retrieve the ledger Eth App object.
    *
    * @returns The ledger Eth App object.
    */

--- a/src/ledger-mobile-bridge/index.ts
+++ b/src/ledger-mobile-bridge/index.ts
@@ -1,0 +1,3 @@
+export * from './middleware';
+export * from './type';
+export * from './ledger-hw-app';

--- a/src/ledger-mobile-bridge/ledger-hw-app.test.ts
+++ b/src/ledger-mobile-bridge/ledger-hw-app.test.ts
@@ -19,7 +19,7 @@ describe('MetaMaskLedgerHwAppEth', function () {
   });
 
   describe('openEthApp', function () {
-    it('transport command should send correctly', async function () {
+    it('should send open eth app command correctly', async function () {
       const ethApp = new MetaMaskLedgerHwAppEth(
         mockTransport as unknown as Transport,
       );
@@ -41,7 +41,7 @@ describe('MetaMaskLedgerHwAppEth', function () {
   });
 
   describe('closeApps', function () {
-    it('transport command should send correctly', async function () {
+    it('should send close app command correctly', async function () {
       const ethApp = new MetaMaskLedgerHwAppEth(
         mockTransport as unknown as Transport,
       );
@@ -57,7 +57,7 @@ describe('MetaMaskLedgerHwAppEth', function () {
   });
 
   describe('getAppNameAndVersion', function () {
-    it('transport command should send correctly', async function () {
+    it('should get appName and appVersion correctly', async function () {
       const appNameBuf = Buffer.alloc(7, 'appName', 'ascii');
       const verionBuf = Buffer.alloc(6, 'verion', 'ascii');
       const buffer = Buffer.alloc(20);
@@ -90,7 +90,26 @@ describe('MetaMaskLedgerHwAppEth', function () {
       });
     });
 
-    it('throw error when buffer incorrect', async function () {
+    it('should not throw error when result length less than expected', async function () {
+      const buffer = Buffer.alloc(1);
+      buffer[0] = 1;
+      const ethApp = new MetaMaskLedgerHwAppEth(
+        mockTransport as unknown as Transport,
+      );
+      const transportSpy = jest
+        .spyOn(mockTransport, 'send')
+        .mockImplementation(async () => Promise.resolve(buffer));
+
+      const result = await ethApp.getAppNameAndVersion();
+      expect(transportSpy).toHaveBeenCalledTimes(1);
+      expect(transportSpy).toHaveBeenCalledWith(0xb0, 0x01, 0x00, 0x00);
+      expect(result).toStrictEqual({
+        appName: '',
+        version: '',
+      });
+    });
+
+    it('should throw error when first byte is not 1', async function () {
       const ethApp = new MetaMaskLedgerHwAppEth(
         mockTransport as unknown as Transport,
       );
@@ -100,7 +119,7 @@ describe('MetaMaskLedgerHwAppEth', function () {
         .mockImplementation(async () => Promise.resolve(Buffer.alloc(1)));
 
       await expect(ethApp.getAppNameAndVersion()).rejects.toThrow(
-        'getAppNameAndVersion: incorrect format',
+        'Incorrect format return from getAppNameAndVersion.',
       );
       expect(transportSpy).toHaveBeenCalledTimes(1);
       expect(transportSpy).toHaveBeenCalledWith(0xb0, 0x01, 0x00, 0x00);

--- a/src/ledger-mobile-bridge/ledger-hw-app.test.ts
+++ b/src/ledger-mobile-bridge/ledger-hw-app.test.ts
@@ -1,0 +1,109 @@
+import Transport from '@ledgerhq/hw-transport';
+
+import { MetaMaskLedgerHwAppEth } from './ledger-hw-app';
+
+const DEVICE_ID = 'DEVICE_ID';
+
+const mockTransport = {
+  deviceModel: {
+    id: DEVICE_ID,
+  },
+  send: jest.fn(),
+  close: jest.fn(),
+  decorateAppAPIMethods: jest.fn(),
+};
+
+describe('MetaMaskLedgerHwAppEth', function () {
+  afterEach(function () {
+    jest.clearAllMocks();
+  });
+
+  describe('openEthApp', function () {
+    it('transport command should send correctly', async function () {
+      const ethApp = new MetaMaskLedgerHwAppEth(
+        mockTransport as unknown as Transport,
+      );
+
+      const transportSpy = jest
+        .spyOn(mockTransport, 'send')
+        .mockImplementation(async () => Promise.resolve(Buffer.alloc(1)));
+
+      await ethApp.openEthApp();
+      expect(transportSpy).toHaveBeenCalledTimes(1);
+      expect(transportSpy).toHaveBeenCalledWith(
+        0xe0,
+        0xd8,
+        0x00,
+        0x00,
+        Buffer.from('Ethereum', 'ascii'),
+      );
+    });
+  });
+
+  describe('closeApps', function () {
+    it('transport command should send correctly', async function () {
+      const ethApp = new MetaMaskLedgerHwAppEth(
+        mockTransport as unknown as Transport,
+      );
+
+      const transportSpy = jest
+        .spyOn(mockTransport, 'send')
+        .mockImplementation(async () => Promise.resolve(Buffer.alloc(1)));
+
+      await ethApp.closeApps();
+      expect(transportSpy).toHaveBeenCalledTimes(1);
+      expect(transportSpy).toHaveBeenCalledWith(0xb0, 0xa7, 0x00, 0x00);
+    });
+  });
+
+  describe('getAppNameAndVersion', function () {
+    it('transport command should send correctly', async function () {
+      const appNameBuf = Buffer.alloc(7, 'appName', 'ascii');
+      const verionBuf = Buffer.alloc(6, 'verion', 'ascii');
+      const buffer = Buffer.alloc(20);
+      buffer[0] = 1;
+      buffer[1] = appNameBuf.length;
+      let j = 2;
+      for (let i = 0; i < appNameBuf.length; i++, j++) {
+        buffer[j] = appNameBuf[i] ?? 0;
+      }
+      buffer[j] = verionBuf.length;
+      j += 1;
+      for (let i = 0; i < verionBuf.length; i++, j++) {
+        buffer[j] = verionBuf[i] ?? 0;
+      }
+
+      const ethApp = new MetaMaskLedgerHwAppEth(
+        mockTransport as unknown as Transport,
+      );
+
+      const transportSpy = jest
+        .spyOn(mockTransport, 'send')
+        .mockImplementation(async () => Promise.resolve(buffer));
+
+      const result = await ethApp.getAppNameAndVersion();
+      expect(transportSpy).toHaveBeenCalledTimes(1);
+      expect(transportSpy).toHaveBeenCalledWith(0xb0, 0x01, 0x00, 0x00);
+      expect(result).toStrictEqual({
+        appName: 'appName',
+        version: 'verion',
+      });
+    });
+
+    it('throw error when buffer incorrect', async function () {
+      const ethApp = new MetaMaskLedgerHwAppEth(
+        mockTransport as unknown as Transport,
+      );
+
+      const transportSpy = jest
+        .spyOn(mockTransport, 'send')
+        .mockImplementation(async () => Promise.resolve(Buffer.alloc(1)));
+
+      await expect(ethApp.getAppNameAndVersion()).rejects.toThrow(
+        'getAppNameAndVersion: incorrect format',
+      );
+      expect(transportSpy).toHaveBeenCalledTimes(1);
+      expect(transportSpy).toHaveBeenCalledWith(0xb0, 0x01, 0x00, 0x00);
+    });
+  });
+});

--- a/src/ledger-mobile-bridge/ledger-hw-app.ts
+++ b/src/ledger-mobile-bridge/ledger-hw-app.ts
@@ -1,0 +1,80 @@
+import LedgerHwAppEth from '@ledgerhq/hw-app-eth';
+// eslint-disable-next-line import/no-nodejs-modules
+import { Buffer } from 'buffer';
+
+import { GetAppNameAndVersionResponse } from './type';
+
+// eslint-disable-next-line @typescript-eslint/consistent-type-definitions
+export interface MetaMaskLedgerHwAppEth extends LedgerHwAppEth {
+  openEthApp(): void;
+  closeApps(): void;
+  getAppNameAndVersion(): Promise<GetAppNameAndVersionResponse>;
+}
+
+export class MetaMaskLedgerHwAppEth
+  extends LedgerHwAppEth
+  implements MetaMaskLedgerHwAppEth
+{
+  readonly mainAppName = 'BOLOS';
+
+  readonly ethAppName = 'Ethereum';
+
+  readonly transportEncoding = 'ascii';
+
+  /**
+   * Method to open Ethereum application on ledger device.
+   *
+   */
+  async openEthApp(): Promise<void> {
+    await this.transport.send(
+      0xe0,
+      0xd8,
+      0x00,
+      0x00,
+      Buffer.from(this.ethAppName, this.transportEncoding),
+    );
+  }
+
+  /**
+   * Method to close all running application on ledger device.
+   *
+   */
+  async closeApps(): Promise<void> {
+    await this.transport.send(0xb0, 0xa7, 0x00, 0x00);
+  }
+
+  /**
+   * Method to get running application name and version on ledger device.
+   *
+   * @returns An object contains appName and version.
+   */
+  async getAppNameAndVersion(): Promise<GetAppNameAndVersionResponse> {
+    const response = await this.transport.send(0xb0, 0x01, 0x00, 0x00);
+
+    let i = 0;
+    const format = response[i];
+    i += 1;
+    if (format !== 1) {
+      throw new Error('getAppNameAndVersion: incorrect format');
+    }
+
+    const nameLength = response[i] ?? 0;
+    i += 1;
+
+    const appName = response
+      .slice(i, (i += nameLength))
+      .toString(this.transportEncoding);
+
+    const versionLength = response[i] ?? 0;
+    i += 1;
+
+    const version = response
+      .slice(i, (i += versionLength))
+      .toString(this.transportEncoding);
+
+    return {
+      appName,
+      version,
+    };
+  }
+}

--- a/src/ledger-mobile-bridge/ledger-hw-app.ts
+++ b/src/ledger-mobile-bridge/ledger-hw-app.ts
@@ -50,14 +50,11 @@ export class MetaMaskLedgerHwAppEth
    */
   async getAppNameAndVersion(): Promise<GetAppNameAndVersionResponse> {
     const response = await this.transport.send(0xb0, 0x01, 0x00, 0x00);
-
-    let i = 0;
-    const format = response[i];
-    i += 1;
-    if (format !== 1) {
-      throw new Error('getAppNameAndVersion: incorrect format');
+    if (response[0] !== 1) {
+      throw new Error('Incorrect format return from getAppNameAndVersion.');
     }
 
+    let i = 1;
     const nameLength = response[i] ?? 0;
     i += 1;
 

--- a/src/ledger-mobile-bridge/ledger-hw-app.ts
+++ b/src/ledger-mobile-bridge/ledger-hw-app.ts
@@ -22,7 +22,7 @@ export class MetaMaskLedgerHwAppEth
   readonly transportEncoding = 'ascii';
 
   /**
-   * Method to open Ethereum application on ledger device.
+   * Method to open ethereum application on ledger device.
    *
    */
   async openEthApp(): Promise<void> {
@@ -44,7 +44,7 @@ export class MetaMaskLedgerHwAppEth
   }
 
   /**
-   * Method to get running application name and version on ledger device.
+   * Method to retrieve the name and version of the running application in ledger device.
    *
    * @returns An object contains appName and version.
    */

--- a/src/ledger-mobile-bridge/middleware.test.ts
+++ b/src/ledger-mobile-bridge/middleware.test.ts
@@ -50,7 +50,7 @@ describe('LedgerTransportMiddleware', function () {
     it('throw error when transport not set', async function () {
       transportMiddleware = new LedgerTransportMiddleware();
       expect(() => transportMiddleware.getTransport()).toThrow(
-        'Ledger transport is not initialized. You must call setTransport first.',
+        'Instance `transport` is not initialized.',
       );
     });
   });

--- a/src/ledger-mobile-bridge/middleware.test.ts
+++ b/src/ledger-mobile-bridge/middleware.test.ts
@@ -1,0 +1,66 @@
+import Transport from '@ledgerhq/hw-transport';
+
+import { LedgerTransportMiddleware } from './middleware';
+
+const DEVICE_ID = 'DEVICE_ID';
+
+const mockTransport = {
+  deviceModel: {
+    id: DEVICE_ID,
+  },
+  send: jest.fn(),
+  close: jest.fn(),
+  decorateAppAPIMethods: jest.fn(),
+};
+
+describe('LedgerTransportMiddleware', function () {
+  let transportMiddleware: LedgerTransportMiddleware;
+
+  beforeEach(async function () {
+    transportMiddleware = new LedgerTransportMiddleware();
+    transportMiddleware.setTransport(mockTransport as unknown as Transport);
+  });
+
+  afterEach(function () {
+    jest.clearAllMocks();
+  });
+
+  describe('dispose', function () {
+    it('transport should close', async function () {
+      await transportMiddleware.dispose();
+      expect(mockTransport.close).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('setTransport', function () {
+    it('transport should set', async function () {
+      transportMiddleware = new LedgerTransportMiddleware();
+      expect(() => transportMiddleware.getTransport()).toThrow(Error);
+      transportMiddleware.setTransport(mockTransport as any);
+      expect(() => transportMiddleware.getTransport()).toBeDefined();
+    });
+  });
+
+  describe('getTransport', function () {
+    it('return transport', async function () {
+      const transport = transportMiddleware.getTransport();
+      expect(transport).toBe(mockTransport);
+    });
+
+    it('throw error when transport not set', async function () {
+      transportMiddleware = new LedgerTransportMiddleware();
+      expect(() => transportMiddleware.getTransport()).toThrow(
+        'Ledger transport is not initialized. You must call setTransport first.',
+      );
+    });
+  });
+
+  describe('getEthApp', function () {
+    it('return eth app', async function () {
+      transportMiddleware = new LedgerTransportMiddleware();
+      transportMiddleware.setTransport(mockTransport as unknown as Transport);
+      const app = transportMiddleware.getEthApp();
+      expect(app).toBeDefined();
+    });
+  });
+});

--- a/src/ledger-mobile-bridge/middleware.ts
+++ b/src/ledger-mobile-bridge/middleware.ts
@@ -49,9 +49,7 @@ export class LedgerTransportMiddleware implements TransportMiddleware {
    */
   getTransport(): Transport {
     if (!this.#transport) {
-      throw new Error(
-        'Ledger transport is not initialized. You must call setTransport first.',
-      );
+      throw new Error('Instance `transport` is not initialized.');
     }
     return this.#transport;
   }

--- a/src/ledger-mobile-bridge/middleware.ts
+++ b/src/ledger-mobile-bridge/middleware.ts
@@ -43,7 +43,7 @@ export class LedgerTransportMiddleware implements TransportMiddleware {
   }
 
   /**
-   * Method to get the transport object.
+   * Method to retrieve the transport object.
    *
    * @returns An generic interface for communicating with a Ledger hardware wallet.
    */
@@ -55,8 +55,8 @@ export class LedgerTransportMiddleware implements TransportMiddleware {
   }
 
   /**
-   * Method to get the  eth app object.
-   * it create a new instance if not exist.
+   * Method to retrieve the eth app object.
+   * it create a new eth app instance if not exist.
    *
    * @returns An generic interface for communicating with a Ledger hardware wallet to perform operation.
    */

--- a/src/ledger-mobile-bridge/middleware.ts
+++ b/src/ledger-mobile-bridge/middleware.ts
@@ -1,0 +1,71 @@
+import type Transport from '@ledgerhq/hw-transport';
+
+import { MetaMaskLedgerHwAppEth } from './ledger-hw-app';
+
+// eslint-disable-next-line @typescript-eslint/consistent-type-definitions
+export interface TransportMiddleware {
+  setTransport(transport: Transport): void;
+  getTransport(): Transport;
+  getEthApp(): MetaMaskLedgerHwAppEth;
+  dispose(): Promise<void>;
+}
+
+/**
+ * LedgerTransportMiddleware is a middleware to communicate with the Ledger device via transport or LedgerHwAppEth
+ */
+export class LedgerTransportMiddleware implements TransportMiddleware {
+  readonly mainAppName = 'BOLOS';
+
+  readonly ethAppName = 'Ethereum';
+
+  readonly transportEncoding = 'ascii';
+
+  #app?: MetaMaskLedgerHwAppEth;
+
+  #transport?: Transport;
+
+  /**
+   * Method to close the transport connection.
+   *
+   */
+  async dispose(): Promise<void> {
+    const transport = this.getTransport();
+    await transport.close();
+  }
+
+  /**
+   * Method to set the transport object.
+   *
+   * @param transport - The transport object for communicating with a Ledger hardware wallet.
+   */
+  setTransport(transport: Transport): void {
+    this.#transport = transport;
+  }
+
+  /**
+   * Method to get the transport object.
+   *
+   * @returns An generic interface for communicating with a Ledger hardware wallet.
+   */
+  getTransport(): Transport {
+    if (!this.#transport) {
+      throw new Error(
+        'Ledger transport is not initialized. You must call setTransport first.',
+      );
+    }
+    return this.#transport;
+  }
+
+  /**
+   * Method to get the  eth app object.
+   * it create a new instance if not exist.
+   *
+   * @returns An generic interface for communicating with a Ledger hardware wallet to perform operation.
+   */
+  getEthApp(): MetaMaskLedgerHwAppEth {
+    if (!this.#app) {
+      this.#app = new MetaMaskLedgerHwAppEth(this.getTransport());
+    }
+    return this.#app;
+  }
+}

--- a/src/ledger-mobile-bridge/type.ts
+++ b/src/ledger-mobile-bridge/type.ts
@@ -3,6 +3,4 @@ export type GetAppNameAndVersionResponse = {
   version: string;
 };
 
-export type LedgerMobileBridgeOptions = {
-  deviceId?: string;
-};
+export type LedgerMobileBridgeOptions = Record<string, never>;

--- a/src/ledger-mobile-bridge/type.ts
+++ b/src/ledger-mobile-bridge/type.ts
@@ -1,0 +1,8 @@
+export type GetAppNameAndVersionResponse = {
+  appName: string;
+  version: string;
+};
+
+export type LedgerMobileBridgeOptions = {
+  deviceId?: string;
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -1601,6 +1601,7 @@ __metadata:
     "@ethereumjs/util": ^8.0.0
     "@lavamoat/allow-scripts": ^2.5.1
     "@ledgerhq/hw-app-eth": ^6.32.0
+    "@ledgerhq/hw-transport": ^6.28.8
     "@ledgerhq/types-cryptoassets": ^7.6.0
     "@ledgerhq/types-devices": ^6.22.4
     "@metamask/auto-changelog": ^3.1.0


### PR DESCRIPTION
This PR is to add `mobile ledger bridge` into the eth-ledger-bridge-keyring

The PR mainly to add `mobile ledger bridge` that share the same interface from `ledger iframe bridge
`
it decouples into 3 parts

**mobile-ledger-bridge.ts** : it is a component that use the same interface from ledger iframe bridge
**mobile-ledger-bridge/middleware.ts**: it is a component to wrap the bluetooth transport layer and the eth app layer
**mobile-ledger-bridge/ledger-hw-app.ts** : it is extended from the ledger eth app, to offer some extra methods to the ledger hardware, such as open eth app, get name and version of the current app