### PR TITLE
refactor: improve error messages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,3 +76,6 @@ node_modules/
 !.yarn/releases
 !.yarn/sdks
 !.yarn/versions
+
+# exclude webstorm profile file
+.idea/

--- a/src/ledger-keyring.test.ts
+++ b/src/ledger-keyring.test.ts
@@ -353,7 +353,9 @@ describe('LedgerKeyring', function () {
     it('throws an error when the bridge getPublicKey method throws an error and it is not an error type', async function () {
       keyring.setHdPath(`m/44'/60'/0'/0`);
       jest.spyOn(bridge, 'getPublicKey').mockRejectedValue('Some error');
-      await expect(keyring.unlock()).rejects.toThrow('Unlock your Ledger device and open the ETH app');
+      await expect(keyring.unlock()).rejects.toThrow(
+        'Unlock your Ledger device and open the ETH app',
+      );
     });
   });
 

--- a/src/ledger-keyring.test.ts
+++ b/src/ledger-keyring.test.ts
@@ -334,7 +334,7 @@ describe('LedgerKeyring', function () {
         keyring.setHdPath(`m/44'/60'/0'/0`);
         jest.spyOn(bridge, 'getPublicKey').mockRejectedValue('Some error');
         await expect(keyring.unlock()).rejects.toThrow(
-          'Unlock your Ledger device and open the ETH app',
+          'ULedger Ethereum app closed. Open it to unlock.',
         );
       });
 

--- a/src/ledger-keyring.test.ts
+++ b/src/ledger-keyring.test.ts
@@ -337,7 +337,7 @@ describe('LedgerKeyring', function () {
           'Unlock your Ledger device and open the ETH app',
         );
       });
-    
+
       it('does not update hdk.publicKey if updateHdk is false', async function () {
         // @ts-expect-error we want to bypass the publicKey property set method
         keyring.hdk = { publicKey: 'ABC' };
@@ -373,12 +373,6 @@ describe('LedgerKeyring', function () {
           .spyOn(bridge, 'getPublicKey')
           .mockRejectedValue(new Error('Some error'));
         await expect(keyring.unlock()).rejects.toThrow('Some error');
-      });
-
-      it('throws an error when the bridge getPublicKey method throws an error and it is not an error type', async function () {
-        keyring.setHdPath(`m/44'/60'/0'/0`);
-        jest.spyOn(bridge, 'getPublicKey').mockRejectedValue('Some error');
-        await expect(keyring.unlock()).rejects.toThrow('Unknown error');
       });
     });
 

--- a/src/ledger-keyring.test.ts
+++ b/src/ledger-keyring.test.ts
@@ -334,7 +334,7 @@ describe('LedgerKeyring', function () {
         keyring.setHdPath(`m/44'/60'/0'/0`);
         jest.spyOn(bridge, 'getPublicKey').mockRejectedValue('Some error');
         await expect(keyring.unlock()).rejects.toThrow(
-          'ULedger Ethereum app closed. Open it to unlock.',
+          'Ledger Ethereum app closed. Open it to unlock.',
         );
       });
 

--- a/src/ledger-keyring.test.ts
+++ b/src/ledger-keyring.test.ts
@@ -353,7 +353,7 @@ describe('LedgerKeyring', function () {
     it('throws an error when the bridge getPublicKey method throws an error and it is not an error type', async function () {
       keyring.setHdPath(`m/44'/60'/0'/0`);
       jest.spyOn(bridge, 'getPublicKey').mockRejectedValue('Some error');
-      await expect(keyring.unlock()).rejects.toThrow('Unknown error');
+      await expect(keyring.unlock()).rejects.toThrow('Unlock your Ledger device and open the ETH app');
     });
   });
 

--- a/src/ledger-keyring.ts
+++ b/src/ledger-keyring.ts
@@ -215,7 +215,7 @@ export class LedgerKeyring extends EventEmitter {
     } catch (error) {
       throw error instanceof Error
         ? error
-        : new Error('Unlock your Ledger device and open the ETH app');
+        : new Error('Ledger Ethereum app closed. Open it to unlock.');
     }
 
     if (updateHdk && payload.chainCode) {

--- a/src/ledger-keyring.ts
+++ b/src/ledger-keyring.ts
@@ -212,7 +212,7 @@ export class LedgerKeyring extends EventEmitter {
         hdPath: path,
       });
     } catch (error) {
-      throw error instanceof Error ? error : new Error('Unknown error');
+      throw error instanceof Error ? error : new Error('Unlock your Ledger device and open the ETH app');
     }
 
     if (updateHdk && payload.chainCode) {

--- a/src/ledger-keyring.ts
+++ b/src/ledger-keyring.ts
@@ -212,7 +212,9 @@ export class LedgerKeyring extends EventEmitter {
         hdPath: path,
       });
     } catch (error) {
-      throw error instanceof Error ? error : new Error('Unlock your Ledger device and open the ETH app');
+      throw error instanceof Error
+        ? error
+        : new Error('Unlock your Ledger device and open the ETH app');
     }
 
     if (updateHdk && payload.chainCode) {


### PR DESCRIPTION
Currently the `ledger-keyring` throws the error `unknown error` when user locks their ledger or didn't turn open the `eth` app in ledger in MM extension. This PR changes to provide a better error message to indicate what happen.