### PR TITLE
feat: Refactor `ledger-mobile-bridge.ts` to properly define the MobileBridge type.

### DIFF
--- a/src/ledger-mobile-bridge.ts
+++ b/src/ledger-mobile-bridge.ts
@@ -1,12 +1,10 @@
 import ledgerService from '@ledgerhq/hw-app-eth/lib/services/ledger';
 import type Transport from '@ledgerhq/hw-transport';
 
-// eslint-disable-next-line import/no-nodejs-modules
 import {
   GetPublicKeyParams,
   GetPublicKeyResponse,
   LedgerBridge,
-  LedgerBridgeOptions,
   LedgerSignMessageParams,
   LedgerSignMessageResponse,
   LedgerSignTransactionParams,
@@ -21,7 +19,8 @@ import {
   LedgerMobileBridgeOptions,
 } from './type';
 
-export type MobileBridge<T extends LedgerBridgeOptions> = LedgerBridge<T> & {
+// MobileBridge Type will always use LedgerBridge with LedgerMobileBridgeOptions
+export type MobileBridge = LedgerBridge<LedgerMobileBridgeOptions> & {
   getAppNameAndVersion(): Promise<GetAppNameAndVersionResponse>;
   openEthApp(): Promise<void>;
   closeApps(): Promise<void>;
@@ -30,9 +29,7 @@ export type MobileBridge<T extends LedgerBridgeOptions> = LedgerBridge<T> & {
 /**
  * LedgerMobileBridge is a bridge between the LedgerKeyring and the LedgerTransportMiddleware.
  */
-export class LedgerMobileBridge
-  implements MobileBridge<LedgerMobileBridgeOptions>
-{
+export class LedgerMobileBridge implements MobileBridge {
   #transportMiddleware?: TransportMiddleware;
 
   #opts: LedgerMobileBridgeOptions;

--- a/src/ledger-mobile-bridge.ts
+++ b/src/ledger-mobile-bridge.ts
@@ -6,6 +6,7 @@ import {
   GetPublicKeyParams,
   GetPublicKeyResponse,
   LedgerBridge,
+  LedgerBridgeOptions,
   LedgerSignMessageParams,
   LedgerSignMessageResponse,
   LedgerSignTransactionParams,
@@ -20,18 +21,17 @@ import {
   LedgerMobileBridgeOptions,
 } from './type';
 
-// eslint-disable-next-line @typescript-eslint/consistent-type-definitions
-export interface LedgerMobileBridge {
+export type MobileBridge<T extends LedgerBridgeOptions> = LedgerBridge<T> & {
   getAppNameAndVersion(): Promise<GetAppNameAndVersionResponse>;
   openEthApp(): Promise<void>;
   closeApps(): Promise<void>;
-}
+};
 
 /**
  * LedgerMobileBridge is a bridge between the LedgerKeyring and the LedgerTransportMiddleware.
  */
 export class LedgerMobileBridge
-  implements LedgerBridge<LedgerMobileBridgeOptions>
+  implements MobileBridge<LedgerMobileBridgeOptions>
 {
   #transportMiddleware?: TransportMiddleware;
 


### PR DESCRIPTION
Current `LedgerMobileBridge` interface didnt extends `LedgerBridge`

This PR will refactor the Ledger-mobile-bridge.ts file to define the Type hierarchy,

MobileBridge type will extends LedgerBridge type with three extra methods.