### PR TITLE
fix: `init` waits for the iframe to be loaded 

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -41,10 +41,10 @@ module.exports = {
   // An object that configures minimum threshold enforcement for coverage results
   coverageThreshold: {
     global: {
-      branches: 89.28,
-      functions: 95.91,
-      lines: 91.32,
-      statements: 91.41,
+      branches: 90.64,
+      functions: 95.95,
+      lines: 93.02,
+      statements: 93.09,
     },
   },
 

--- a/src/ledger-iframe-bridge.test.ts
+++ b/src/ledger-iframe-bridge.test.ts
@@ -107,8 +107,8 @@ describe('LedgerIframeBridge', function () {
 
   describe('init', function () {
     it('sets up the listener and iframe', async function () {
-      const addEventListenerSpy = jest.spyOn(global.window, 'addEventListener');
       bridge = new LedgerIframeBridge();
+      const addEventListenerSpy = jest.spyOn(global.window, 'addEventListener');
 
       await bridge.init();
 
@@ -519,9 +519,7 @@ describe('LedgerIframeBridge', function () {
     describe('when configurate bridge url', function () {
       describe('when given bridge url is different with current', function () {
         beforeEach(async () => {
-          await bridge.setOptions({
-            bridgeUrl: 'https://metamask.io',
-          });
+          await bridge.setOptions({ bridgeUrl: 'https://metamask.io' });
         });
 
         it('should set bridgeUrl correctly', async function () {

--- a/test/document.shim.ts
+++ b/test/document.shim.ts
@@ -1,32 +1,25 @@
 // eslint-disable-next-line import/no-mutable-exports
 let documentShim: any;
 
+const shim = {
+  head: {
+    appendChild: (child: { onload?: () => void }) => {
+      child.onload?.();
+    },
+  },
+  createElement: () => ({
+    src: false,
+    contentWindow: {
+      postMessage: () => false,
+    },
+  }),
+  addEventListener: () => false,
+};
+
 try {
-  documentShim = document || {
-    head: {
-      appendChild: () => false,
-    },
-    createElement: () => ({
-      src: false,
-      contentWindow: {
-        postMessage: () => false,
-      },
-    }),
-    addEventListener: () => false,
-  };
+  documentShim = document || shim;
 } catch (error) {
-  documentShim = {
-    head: {
-      appendChild: () => false,
-    },
-    createElement: () => ({
-      src: false,
-      contentWindow: {
-        postMessage: () => false,
-      },
-    }),
-    addEventListener: () => false,
-  };
+  documentShim = shim;
 }
 
 export default documentShim;


### PR DESCRIPTION
Currently, `updateTransportMethod` stores a promise in a class variable that will resolve only when the iframe is loaded. Though, there are instances when this mechanism is broken - like when `updateTransportMethod` is called multiple times.

This PR changes the `init` method to wait for the iframe to be fully loaded before resolving. This implies that when `updateTransportMethod` is called, the bridge needs to be already initialized (with `init`), or an error is thrown 

Fixes #70 