### PR TITLE
fix: normalize signature v value for proper recovery

### DIFF
--- a/src/ledger-keyring.test.ts
+++ b/src/ledger-keyring.test.ts
@@ -840,6 +840,82 @@ describe('LedgerKeyring', function () {
           'Ledger: The signature doesnt match the right address',
         );
       });
+
+      it('normalizes v=0 to v=27 for proper signature recovery', async function () {
+        await basicSetupToUnlockOneAccount();
+        jest
+          .spyOn(keyring.bridge, 'deviceSignMessage')
+          .mockResolvedValue({ v: 0, r: 'aabbccdd', s: '11223344' });
+
+        jest
+          .spyOn(sigUtil, 'recoverPersonalSignature')
+          .mockReturnValue(fakeAccounts[0]);
+
+        const result = await keyring.signPersonalMessage(
+          fakeAccounts[0],
+          'some message',
+        );
+
+        // v=0 should be normalized to v=27 (0x1b)
+        expect(result).toBe('0xaabbccdd112233441b');
+      });
+
+      it('normalizes v=1 to v=28 for proper signature recovery', async function () {
+        await basicSetupToUnlockOneAccount();
+        jest
+          .spyOn(keyring.bridge, 'deviceSignMessage')
+          .mockResolvedValue({ v: 1, r: 'aabbccdd', s: '11223344' });
+
+        jest
+          .spyOn(sigUtil, 'recoverPersonalSignature')
+          .mockReturnValue(fakeAccounts[0]);
+
+        const result = await keyring.signPersonalMessage(
+          fakeAccounts[0],
+          'some message',
+        );
+
+        // v=1 should be normalized to v=28 (0x1c)
+        expect(result).toBe('0xaabbccdd112233441c');
+      });
+
+      it('preserves v=27 unchanged', async function () {
+        await basicSetupToUnlockOneAccount();
+        jest
+          .spyOn(keyring.bridge, 'deviceSignMessage')
+          .mockResolvedValue({ v: 27, r: 'aabbccdd', s: '11223344' });
+
+        jest
+          .spyOn(sigUtil, 'recoverPersonalSignature')
+          .mockReturnValue(fakeAccounts[0]);
+
+        const result = await keyring.signPersonalMessage(
+          fakeAccounts[0],
+          'some message',
+        );
+
+        // v=27 should remain as 0x1b
+        expect(result).toBe('0xaabbccdd112233441b');
+      });
+
+      it('preserves v=28 unchanged', async function () {
+        await basicSetupToUnlockOneAccount();
+        jest
+          .spyOn(keyring.bridge, 'deviceSignMessage')
+          .mockResolvedValue({ v: 28, r: 'aabbccdd', s: '11223344' });
+
+        jest
+          .spyOn(sigUtil, 'recoverPersonalSignature')
+          .mockReturnValue(fakeAccounts[0]);
+
+        const result = await keyring.signPersonalMessage(
+          fakeAccounts[0],
+          'some message',
+        );
+
+        // v=28 should remain as 0x1c
+        expect(result).toBe('0xaabbccdd112233441c');
+      });
     });
 
     describe('signMessage', function () {
@@ -1043,7 +1119,9 @@ describe('LedgerKeyring', function () {
         ).rejects.toThrow('Ledger: Unknown error while signing message');
       });
 
-      it('returns signature when recoveryId length < 2', async function () {
+      it('normalizes v=0 to v=27 for proper signature recovery', async function () {
+        // Ledger may return v as 0 or 1 (modern format), but signature
+        // recovery expects 27 or 28 (legacy format)
         jest.spyOn(keyring.bridge, 'deviceSignTypedData').mockResolvedValue({
           v: 0,
           r: '72d4e38a0e582e09a620fd38e236fe687a1ec782206b56d576f579c026a7e5b9',
@@ -1054,8 +1132,41 @@ describe('LedgerKeyring', function () {
           fixtureData,
           options,
         );
+        // v=0 should be normalized to v=27 (0x1b)
         expect(result).toBe(
-          '0x72d4e38a0e582e09a620fd38e236fe687a1ec782206b56d576f579c026a7e5b946759735981cd0c3efb02d36df28bb2feedfec3d90e408efc93f45b894946e3200',
+          '0x72d4e38a0e582e09a620fd38e236fe687a1ec782206b56d576f579c026a7e5b946759735981cd0c3efb02d36df28bb2feedfec3d90e408efc93f45b894946e321b',
+        );
+      });
+
+      it('normalizes v=1 to v=28 for proper signature recovery', async function () {
+        jest.spyOn(keyring.bridge, 'deviceSignTypedData').mockResolvedValue({
+          v: 1,
+          r: '72d4e38a0e582e09a620fd38e236fe687a1ec782206b56d576f579c026a7e5b9',
+          s: '46759735981cd0c3efb02d36df28bb2feedfec3d90e408efc93f45b894946e32',
+        });
+
+        // v=1 should be normalized to v=28 (0x1c), but this will fail
+        // address recovery since the correct v for this signature is 27
+        await expect(
+          keyring.signTypedData(fakeAccounts[15], fixtureData, options),
+        ).rejects.toThrow(
+          'Ledger: The signature doesnt match the right address',
+        );
+      });
+
+      it('preserves v=27 unchanged', async function () {
+        jest.spyOn(keyring.bridge, 'deviceSignTypedData').mockResolvedValue({
+          v: 27,
+          r: '72d4e38a0e582e09a620fd38e236fe687a1ec782206b56d576f579c026a7e5b9',
+          s: '46759735981cd0c3efb02d36df28bb2feedfec3d90e408efc93f45b894946e32',
+        });
+        const result = await keyring.signTypedData(
+          fakeAccounts[15],
+          fixtureData,
+          options,
+        );
+        expect(result).toBe(
+          '0x72d4e38a0e582e09a620fd38e236fe687a1ec782206b56d576f579c026a7e5b946759735981cd0c3efb02d36df28bb2feedfec3d90e408efc93f45b894946e321b',
         );
       });
     });

--- a/src/ledger-keyring.ts
+++ b/src/ledger-keyring.ts
@@ -425,7 +425,13 @@ export class LedgerKeyring extends EventEmitter {
         : new Error('Ledger: Unknown error while signing message');
     }
 
-    let modifiedV = parseInt(String(payload.v), 10).toString(16);
+    let recoveryParam = parseInt(String(payload.v), 10);
+    // Normalize: Ledger may return 0 or 1 (modern format), but signature
+    // recovery expects 27 or 28 (legacy format per EIP-191)
+    if (recoveryParam === 0 || recoveryParam === 1) {
+      recoveryParam += 27;
+    }
+    let modifiedV = recoveryParam.toString(16);
     if (modifiedV.length < 2) {
       modifiedV = `0${modifiedV}`;
     }
@@ -511,7 +517,13 @@ export class LedgerKeyring extends EventEmitter {
         : new Error('Ledger: Unknown error while signing message');
     }
 
-    let recoveryId = parseInt(String(payload.v), 10).toString(16);
+    let recoveryParam = parseInt(String(payload.v), 10);
+    // Normalize: Ledger may return 0 or 1 (modern format), but signature
+    // recovery expects 27 or 28 (legacy format per EIP-712)
+    if (recoveryParam === 0 || recoveryParam === 1) {
+      recoveryParam += 27;
+    }
+    let recoveryId = recoveryParam.toString(16);
     if (recoveryId.length < 2) {
       recoveryId = `0${recoveryId}`;
     }


### PR DESCRIPTION
## Summary

Ledger devices may return signature `v` as 0 or 1 (modern format), but Ethereum's `ecrecover` expects 27 or 28 ([Yellow Paper](https://ethereum.github.io/yellowpaper/paper.pdf)). This causes `"The signature doesnt match the right address"` errors in `signPersonalMessage` and `signTypedData`.

## Fix

```typescript
if (recoveryParam === 0 || recoveryParam === 1) {
  recoveryParam += 27;
}
```

## Why This Wasn't Fixed Before

**Original bug (pre-2022):** The code *subtracted* 27 from `v`:
```javascript
let v = payload.v - 27  // WRONG
```
This converted correct values (27/28) into incorrect ones (0/1).

**PR #152 (August 2022):** Changed to pass through the raw value:
```javascript
let v = parseInt(payload.v, 10)  // Just pass through
```
This fixed the case where Ledger returns 27/28, but assumed Ledger *always* returns 27/28.

**The gap:** Ledger devices may return 0/1 depending on firmware, signing method, or device model. PR #152 didn't normalize these values.

**Issue #10850 was closed prematurely** in January 2024 with "I expect this was resolved in PR #152" — but PR #152 only fixed one direction of the problem.

## References

This is a well-known issue with a standard fix across the ecosystem:

- [Frame wallet](https://github.com/floating/frame/blob/0.6.10/main/provider/helpers.ts#L10) - `v = v === 0 || v === 1 ? v + 27 : v`
- [Rabby wallet](https://github.com/RabbyHub/Rabby/blob/develop/src/ui/utils/gnosis.ts) - Rabby explicitly mentions MM bug *"Metamask with ledger returns V=0/1 here too"*
- [Gnosis Safe Android](https://github.com/safe-global/safe-android/blob/main/app/src/main/java/io/gnosis/safe/ui/transactions/details/viewmodel/TxReviewViewModel.kt) - `if (v <= 1) v += 27`
- Related issues: [#134](https://github.com/MetaMask/eth-ledger-bridge-keyring/issues/134), [#151](https://github.com/MetaMask/eth-ledger-bridge-keyring/issues/151), [metamask-extension#10850](https://github.com/MetaMask/metamask-extension/issues/10850)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches signature construction/verification in `signPersonalMessage` and `signTypedData`, which is correctness-critical and could change produced signatures for some devices/firmware. Scope is small and covered by added tests for v normalization and legacy passthrough.
> 
> **Overview**
> Fixes Ledger message signing when devices return `v` as `0/1` by normalizing to `27/28` before building the final signature in `signPersonalMessage` and `signTypedData`.
> 
> Updates and expands tests to cover normalization for `v=0` and `v=1` and to confirm `v=27/28` behavior is preserved, preventing address-recovery mismatches ("The signature doesnt match the right address").
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 82d7e9594bde18653cc5a99698f8640045bd91e0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->